### PR TITLE
Account security (batch 1 UI): Users-page lock toggle + nickname/optional-email

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1015,7 +1015,7 @@ components:
         role_ids: { type: array, items: { type: string } }
     UserUpdateRequest:
       type: object
-      required: [user_id, username, email, role_ids]
+      required: [user_id, username, role_ids]
       properties:
         user_id: { type: string }
         username: { type: string }

--- a/packages/mws/src/managers/admin-users.ts
+++ b/packages/mws/src/managers/admin-users.ts
@@ -166,12 +166,15 @@ export class UserManager {
   user_update = admin(z => z.object({
     user_id: z.prismaField("Users", "user_id", "string"),
     username: z.prismaField("Users", "username", "string"),
-    email: z.prismaField("Users", "email", "string"),
+    email: z.prismaField("Users", "email", "string").optional(),
     nickname: z.string().optional(),
     role_ids: z.prismaField("Roles", "role_id", "string").array(),
   }), async (state, prisma) => {
-    const { user_id, username, email, role_ids } = state.data;
+    const { user_id, username, role_ids } = state.data;
     const nickname = state.data.nickname?.trim() || null;
+    // Email is optional (matching user_create + the UI): a blank/omitted value leaves the
+    // existing email unchanged, rather than forcing one or clobbering it with a placeholder.
+    const email = state.data.email?.trim();
 
     state.okAdmin();
 
@@ -197,7 +200,7 @@ export class UserManager {
     try {
       await prisma.users.update({
         where: { user_id },
-        data: { username, email, nickname, roles: { set: role_ids.map(role_id => ({ role_id })) } }
+        data: { username, ...(email ? { email } : {}), nickname, roles: { set: role_ids.map(role_id => ({ role_id })) } }
       });
     } catch (error) {
       handlePrismaUniqueConstraintError(error);

--- a/packages/mws/src/templates/htmx-admin-poc.html
+++ b/packages/mws/src/templates/htmx-admin-poc.html
@@ -27,12 +27,13 @@
             <th>Roles</th>
             <th>Last Login</th>
             <th>Created</th>
+            <th>Status</th>
             <th>Actions</th>
           </tr>
         </thead>
         <tbody id="users-tbody">
           <tr>
-            <td colspan="6" class="mws-loading">
+            <td colspan="7" class="mws-loading">
               <div class="mws-spinner"></div>
               <div>Loading users...</div>
             </td>
@@ -59,8 +60,13 @@
           </div>
 
           <div class="mws-form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" name="email" class="mws-form-input" autocomplete="email" required>
+            <label for="email">Email <span class="mws-text-muted">(optional)</span></label>
+            <input type="email" id="email" name="email" class="mws-form-input" autocomplete="email">
+          </div>
+
+          <div class="mws-form-group">
+            <label for="nickname">Nickname <span class="mws-text-muted">(optional — shown in the wikis)</span></label>
+            <input type="text" id="nickname" name="nickname" class="mws-form-input" autocomplete="nickname">
           </div>
 
           <div class="mws-form-group">
@@ -190,22 +196,26 @@
       const tbody = document.getElementById('users-tbody');
 
       if (allUsers.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="6" style="text-align: center;" class="mws-text-muted">No users found</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7" style="text-align: center;" class="mws-text-muted">No users found</td></tr>';
         return;
       }
 
       tbody.innerHTML = allUsers.map(user => `
-        <tr id="user-${escapeHtml(user.user_id)}">
-          <td><strong>${escapeHtml(user.username)}</strong></td>
+        <tr id="user-${escapeHtml(user.user_id)}"${user.disabled ? ' style="opacity:.55;"' : ''}>
+          <td><strong>${escapeHtml(user.username)}</strong>${user.nickname ? ` <span class="mws-text-muted">(${escapeHtml(user.nickname)})</span>` : ''}</td>
           <td>${escapeHtml(user.email)}</td>
           <td>
             ${user.roles.map(role => `<span class="mws-badge">${escapeHtml(role.role_name)}</span>`).join('')}
           </td>
           <td>${user.last_login ? formatDate(user.last_login) : '<span class="mws-text-muted">Never</span>'}</td>
           <td>${formatDate(user.created_at)}</td>
+          <td>${user.disabled
+            ? '<span class="mws-badge" style="background:#c0392b;color:#fff;">Disabled</span>'
+            : '<span class="mws-badge" style="background:#27ae60;color:#fff;">Active</span>'}</td>
           <td>
             <div class="mws-btn-group">
               <button class="mws-btn mws-btn-primary mws-btn-sm" data-action="edit" data-user-id="${escapeHtml(user.user_id)}">Edit</button>
+              <button class="mws-btn mws-btn-sm" data-action="toggle-disabled" data-user-id="${escapeHtml(user.user_id)}" data-disabled="${user.disabled ? '1' : '0'}">${user.disabled ? 'Unlock' : 'Lock'}</button>
               <button class="mws-btn mws-btn-danger mws-btn-sm" data-action="delete" data-user-id="${escapeHtml(user.user_id)}" data-username="${escapeHtml(user.username)}">Delete</button>
             </div>
           </td>
@@ -230,7 +240,7 @@
         if (!data.isAdmin) {
           showToast('Admin access required to manage users', 'error');
           document.getElementById('users-tbody').innerHTML =
-            '<tr><td colspan="6" style="text-align: center;" class="mws-text-muted">Admin access required</td></tr>';
+            '<tr><td colspan="7" style="text-align: center;" class="mws-text-muted">Admin access required</td></tr>';
           return false;
         }
         return true;
@@ -262,6 +272,7 @@
         document.getElementById('user_id').value = data.user.user_id;
         document.getElementById('username').value = data.user.username;
         document.getElementById('email').value = data.user.email;
+        document.getElementById('nickname').value = data.user.nickname || '';
 
         allRoles = data.allRoles;
         populateRoles(data.user.roles.map(r => r.role_id));
@@ -355,15 +366,16 @@
         const userId = formData.get('user_id');
         const username = formData.get('username');
         const email = formData.get('email');
+        const nickname = formData.get('nickname');
         const role_ids = formData.getAll('role_ids');
 
         if (userId) {
           // Update existing user
-          await apiRequest('user_update', { user_id: userId, username, email, role_ids });
+          await apiRequest('user_update', { user_id: userId, username, email, nickname, role_ids });
           showToast('User updated successfully', 'success');
         } else {
           // Create new user
-          await apiRequest('user_create', { username, email, role_ids });
+          await apiRequest('user_create', { username, email, nickname, role_ids });
           showToast('User created successfully', 'success');
         }
 
@@ -389,6 +401,22 @@
         await loadUsers();
       } catch (error) {
         showToast('Failed to delete user: ' + error.message, 'error');
+      }
+    }
+
+    // Lock (disable) / unlock (enable) an account
+    async function toggleDisabled(userId, currentlyDisabled) {
+      const makeDisabled = !currentlyDisabled;
+      const verb = makeDisabled ? 'lock (disable)' : 'unlock (enable)';
+      if (!confirm(`Are you sure you want to ${verb} this account?`)) {
+        return;
+      }
+      try {
+        await apiRequest('user_set_disabled', { user_id: userId, disabled: makeDisabled });
+        showToast(`Account ${makeDisabled ? 'locked' : 'unlocked'}`, 'success');
+        await loadUsers();
+      } catch (error) {
+        showToast('Failed to update account: ' + error.message, 'error');
       }
     }
 
@@ -486,6 +514,8 @@
 
             if (action === 'edit' && userId) {
               showEditModal(userId);
+            } else if (action === 'toggle-disabled' && userId) {
+              toggleDisabled(userId, target.dataset.disabled === '1');
             } else if (action === 'delete' && userId) {
               const username = target.dataset.username;
               deleteUser(userId, username);

--- a/packages/mws/src/templates/htmx-admin-poc.html
+++ b/packages/mws/src/templates/htmx-admin-poc.html
@@ -130,6 +130,7 @@
     const pathPrefix = '{{pathPrefix}}';
     let allRoles = [];
     let allUsers = [];
+    let currentUserId = null;
 
     // Utility: Make API request
     async function apiRequest(endpoint, data) {
@@ -215,7 +216,7 @@
           <td>
             <div class="mws-btn-group">
               <button class="mws-btn mws-btn-primary mws-btn-sm" data-action="edit" data-user-id="${escapeHtml(user.user_id)}">Edit</button>
-              <button class="mws-btn mws-btn-sm" data-action="toggle-disabled" data-user-id="${escapeHtml(user.user_id)}" data-disabled="${user.disabled ? '1' : '0'}">${user.disabled ? 'Unlock' : 'Lock'}</button>
+              ${user.user_id !== currentUserId ? `<button class="mws-btn mws-btn-sm" data-action="toggle-disabled" data-user-id="${escapeHtml(user.user_id)}" data-disabled="${user.disabled ? '1' : '0'}">${user.disabled ? 'Unlock' : 'Lock'}</button>` : ''}
               <button class="mws-btn mws-btn-danger mws-btn-sm" data-action="delete" data-user-id="${escapeHtml(user.user_id)}" data-username="${escapeHtml(user.username)}">Delete</button>
             </div>
           </td>
@@ -229,6 +230,7 @@
         // Get roles and other data from index endpoint
         const data = await apiRequest('index_json', undefined);
         allRoles = data.roleList || [];
+        currentUserId = data.user_id || null;
 
         // Update version info in dropdown
         if (data.versions) {


### PR DESCRIPTION
Closes #8. Completes the Batch 1 UI (backend merged in #7).

## Changes (`htmx-admin-poc.html`)
- **Status column** (Active / Disabled) + a per-row **Lock / Unlock** button calling `user_set_disabled`; disabled rows are dimmed.
- **Nickname** (optional) and **optional email** in the create/edit form — nickname populated on edit and sent to `user_create`/`user_update`; the username cell shows the nickname in parentheses when set.

## Verification
- `npm run test:unit` 93/93.
- Headless admin smoke passes (Users page loads in a real browser, no `pageerror`/`console.error`).
- Full pre-push gate green.

UI-only; the backend (`user_set_disabled`, nickname, optional email) is already on `Alternative-to-react`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users admin table now displays a Status column showing active/disabled user status
  * Added Lock/Unlock toggle controls for managing individual user access
  * Nickname field is now optional in user creation and editing forms
  * User edit modal now populates the Nickname field with existing data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->