### PR TITLE
Account security (batch 2): login rate-limiting

### DIFF
--- a/docs/SDP.md
+++ b/docs/SDP.md
@@ -114,8 +114,9 @@ is referenced from root deps as `prisma-client file:prisma/client`.
   GAP: no SP 800-53 control mapping; no key-rotation procedure for the password master key.
 - **OWASP**: API Top-10 wired via `.spectral.yaml`, enforced by `openapi-coverage` at
   `--fail-severity=error`; CSRF (`X-Requested-With` + same-origin referer host), output
-  escaping, the broken-access-control + error-handling fixes above. GAP: no rate limiting
-  (api4 is `warn`-only); no CSRF token (defense-in-depth).
+  escaping, the broken-access-control + error-handling fixes above, and **login rate-limiting**
+  (in-memory per-username throttle on `/login/1`). GAP: no general per-route rate limiting (api4
+  is `warn`-only); no CSRF token (defense-in-depth).
 - **FIPS 140-3** (uplifted from the workspace's "140-2" — 140-2 is superseded): the stack is
   **NOT FIPS-validated** and largely can't be without major change. See the dedicated path in
   §7. Do **not** claim FIPS compliance.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -46,10 +46,10 @@ these are polish, not correctness):
       (tailnet-only HTTPS); Funnel is OFF** (no public internet). Defense-in-depth: tailnet
       boundary + per-request role auth + CSRF (`X-Requested-With` + same-origin referer-host).
       Net: a tailnet peer (e.g. a node-shared family device) STILL needs a valid login — reach ≠ read.
-- [ ] **Possible hardening from the above finding:** no rate-limiting / lockout on `POST /login`
-      (OPAQUE) — a tailnet peer could brute-force/credential-stuff; add login throttling
-      (OWASP API4; SDP §6 already flags "no rate limiting"). Also keep Funnel OFF (document as a
-      standing invariant), and consider an alert if the listener ever binds non-loopback.
+- [x] **Login throttling — DONE (batch 2):** in-memory per-username rate limit/lockout on
+      `POST /login/1` (`SessionManager.checkLoginRateLimit`); keyed by username (per-IP is moot
+      behind the loopback proxy). Remaining: keep Funnel OFF (standing invariant), consider an
+      alert if the listener ever binds non-loopback, and a general per-route rate limit (API4).
 - [ ] Decide FIPS-140-3 scope (recommend: documented non-goal for this deployment) — record it.
 - [ ] Threat model (`docs/security.md`); password-master-key rotation procedure; backup/retention policy.
 - [ ] SBOM / transitive license scan.

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,7 @@ family-app deployment.
 | Standard | Status |
 |---|---|
 | **NIST** | SP 800-63B-style authentication via OPAQUE (no password transmitted or stored as a recoverable hash). Session cookie is `HttpOnly` + `SameSite=Strict` + `Secure` (behind a TLS-terminating proxy with `secure=true`). **Gap:** no SP 800-53 control mapping; no documented key-rotation procedure for the password master key (`passwords.key`). |
-| **OWASP** | API Top-10 ruleset wired via `.spectral.yaml`, enforced by the `openapi-coverage` skill at `--fail-severity=error`. CSRF (`X-Requested-With` + same-origin referer **host**), output escaping, and the broken-access-control + error-handling fixes (see below). **Gap:** no rate limiting (OWASP API4 is `warn`-only); no anti-CSRF token (defense-in-depth). |
+| **OWASP** | API Top-10 ruleset wired via `.spectral.yaml`, enforced by the `openapi-coverage` skill at `--fail-severity=error`. CSRF (`X-Requested-With` + same-origin referer **host**), output escaping, **login rate-limiting** (per-username throttle on `/login/1`, see below), and the broken-access-control + error-handling fixes. **Gap:** no general per-route rate limiting (OWASP API4 is `warn`-only); no anti-CSRF token (defense-in-depth). |
 | **FIPS 140-3** | **Not FIPS-validated**, and largely cannot be without major change (OPAQUE's WASM crypto, Tailscale transport, and the Pi/Debian host are not validated modules). **Recorded decision: FIPS-140-3 is a documented non-goal for the current reference deployment (tailnet-only, behind Tailscale).** A deployment with stricter requirements would need the phased path in `SDP.md` §7. Do not claim FIPS compliance. See [`SDP.md`](SDP.md) §7 for the full analysis and the phased path if it ever becomes a requirement. |
 
 > Note: the workspace standard references FIPS 140-2; 140-2 is superseded by **140-3**, which
@@ -65,6 +65,11 @@ satisfies all of them.
   a same-origin `referer` whose **host** matches the request Host. The host check closed an
   `evil.com/admin` bypass that the earlier pathname-only check allowed; verified live behind
   `tailscale serve`. See `packages/mws/src/managers/admin-utils.ts`.
+- **Login rate-limiting** — an in-memory, per-username throttle on `POST /login/1`
+  (`SessionManager.checkLoginRateLimit`): after a burst of login starts within a window the
+  username is locked out for a cooldown. Keyed by username because behind Tailscale Serve the
+  client IP is always the loopback proxy; with OPAQUE a wrong password fails client-side, so the
+  `/login/1` start is the server-side attempt signal. Resets on process restart.
 - **Authorization (ACL)** — role-based read/write on bags and recipes. A high-severity fix
   corrected `getRecipeACL`/`getBagACL` to read `roles.map(r => r.role_id)` (the code previously
   read an always-`undefined` `role_ids`, so non-admins could only reach resources they owned).
@@ -87,7 +92,7 @@ satisfies all of them.
 
 | STRIDE | Surface | Current mitigation | Open |
 |---|---|---|---|
-| **S**poofing | Login | OPAQUE; session cookie | Brute-force throttling |
+| **S**poofing | Login | OPAQUE; session cookie; login rate-limiting (per-username) | Distributed/credential-stuffing across many usernames |
 | **T**ampering | Admin/sync APIs | CSRF header + referer-host; ACL | Anti-CSRF token |
 | **R**epudiation | Admin actions | Server event log | Audit-log retention policy |
 | **I**nfo disclosure | Tiddler/bag reads | ACL; `Secure` cookie over TLS | At-rest encryption |

--- a/packages/mws/src/services/__tests__/sessions.test.ts
+++ b/packages/mws/src/services/__tests__/sessions.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Login rate-limiting (batch 2): SessionManager.checkLoginRateLimit.
+ * Time is injected via the `now` argument so the tests are deterministic (no fake timers).
+ * Each test uses a unique username to avoid sharing the static in-memory map.
+ */
+import { describe, it, expect } from "vitest";
+import { SessionManager } from "../sessions";
+
+const MAX = SessionManager.LOGIN_MAX_ATTEMPTS;
+const WINDOW = SessionManager.LOGIN_WINDOW_MS;
+const LOCKOUT = SessionManager.LOGIN_LOCKOUT_MS;
+
+describe("SessionManager.checkLoginRateLimit", () => {
+  it("allows up to LOGIN_MAX_ATTEMPTS starts in the window, then locks out", () => {
+    const u = "rl-user-burst";
+    const t0 = 1_000_000;
+    for (let i = 0; i < MAX; i++) {
+      expect(() => SessionManager.checkLoginRateLimit(u, t0 + i)).not.toThrow();
+    }
+    // The attempt past the cap trips the lockout, and it stays locked.
+    expect(() => SessionManager.checkLoginRateLimit(u, t0 + MAX)).toThrow(/Too many login attempts/);
+    expect(() => SessionManager.checkLoginRateLimit(u, t0 + MAX + 5)).toThrow(/Too many login attempts/);
+  });
+
+  it("unlocks after the lockout period elapses", () => {
+    const u = "rl-user-unlock";
+    const t0 = 5_000_000;
+    for (let i = 0; i <= MAX; i++) {
+      try { SessionManager.checkLoginRateLimit(u, t0 + i); } catch { /* the (MAX+1)th locks */ }
+    }
+    expect(() => SessionManager.checkLoginRateLimit(u, t0 + 1000)).toThrow(/Too many login attempts/);
+    // lockedUntil = (t0 + MAX) + LOCKOUT; just past it, attempts are allowed again.
+    const after = t0 + MAX + LOCKOUT + 1;
+    expect(() => SessionManager.checkLoginRateLimit(u, after)).not.toThrow();
+  });
+
+  it("does not lock out when attempts are spread beyond the window", () => {
+    const u = "rl-user-spread";
+    for (let i = 0; i < MAX + 5; i++) {
+      const t = i * (WINDOW + 1000);
+      expect(() => SessionManager.checkLoginRateLimit(u, t)).not.toThrow();
+    }
+  });
+});

--- a/packages/mws/src/services/__tests__/sessions.test.ts
+++ b/packages/mws/src/services/__tests__/sessions.test.ts
@@ -41,4 +41,13 @@ describe("SessionManager.checkLoginRateLimit", () => {
       expect(() => SessionManager.checkLoginRateLimit(u, t)).not.toThrow();
     }
   });
+
+  it("stays bounded under a spray of distinct fresh usernames", () => {
+    // All within one window, so the staleness check can't reclaim them — the hard cap must.
+    const cap = SessionManager.LOGIN_MAX_TRACKED;
+    for (let i = 0; i < cap + 1000; i++) {
+      SessionManager.checkLoginRateLimit("spray-" + i, 1_000 + i);
+    }
+    expect(SessionManager.loginTrackedCount).toBeLessThanOrEqual(cap);
+  });
 });

--- a/packages/mws/src/services/sessions.ts
+++ b/packages/mws/src/services/sessions.ts
@@ -91,6 +91,49 @@ export class SessionManager {
     registerZodRoutes(root, new SessionManager(), Object.keys(SessionKeyMap))
   }
 
+  // ── Login rate limiting ──────────────────────────────────────────────────
+  // In-memory, per-username throttle on /login/1 (resets on process restart; mirrors the
+  // passwordGenerationCooldowns pattern). Keyed by USERNAME deliberately: behind a TLS proxy
+  // (Tailscale Serve) the client IP is always the loopback proxy, so per-IP limiting is not
+  // meaningful here. With OPAQUE a wrong password fails client-side, so the server-side signal
+  // of an attempt is the /login/1 start — that is what we count. Tradeoff: a username-keyed
+  // lockout can be used to temporarily lock a victim out (acceptable on a tailnet-only deploy).
+  private static loginAttempts = new Map<string, { times: number[]; lockedUntil: number }>();
+  static readonly LOGIN_WINDOW_MS = 15 * 60_000;   // sliding window
+  static readonly LOGIN_MAX_ATTEMPTS = 10;         // starts allowed per window
+  static readonly LOGIN_LOCKOUT_MS = 15 * 60_000;  // lock duration once exceeded
+
+  /** Throws a user-facing string if the username is locked out or exceeds the attempt cap. */
+  static checkLoginRateLimit(username: string, now: number = Date.now()): void {
+    const rec = SessionManager.loginAttempts.get(username) ?? { times: [], lockedUntil: 0 };
+
+    if (rec.lockedUntil > now) {
+      const mins = Math.ceil((rec.lockedUntil - now) / 60_000);
+      throw `Too many login attempts. Try again in ${mins} minute${mins === 1 ? "" : "s"}.`;
+    }
+
+    rec.times = rec.times.filter(t => now - t < SessionManager.LOGIN_WINDOW_MS);
+    rec.times.push(now);
+
+    if (rec.times.length > SessionManager.LOGIN_MAX_ATTEMPTS) {
+      rec.lockedUntil = now + SessionManager.LOGIN_LOCKOUT_MS;
+      rec.times = [];
+      SessionManager.loginAttempts.set(username, rec);
+      throw `Too many login attempts. Try again in ${Math.ceil(SessionManager.LOGIN_LOCKOUT_MS / 60_000)} minutes.`;
+    }
+
+    SessionManager.loginAttempts.set(username, rec);
+
+    // Opportunistic cleanup so the map can't grow unbounded.
+    if (SessionManager.loginAttempts.size > 1000) {
+      for (const [k, v] of SessionManager.loginAttempts) {
+        const last = v.times[v.times.length - 1] ?? 0;
+        if (v.lockedUntil < now && now - last > SessionManager.LOGIN_WINDOW_MS)
+          SessionManager.loginAttempts.delete(k);
+      }
+    }
+  }
+
   static async parseIncomingRequest(streamer: Streamer, config: ServerState): Promise<AuthUser> {
 
     const sessionId = streamer.cookies.getAll("session") as PrismaField<"Sessions", "session_id">[];
@@ -128,6 +171,9 @@ export class SessionManager {
     startLoginRequest: z.string(),
   }), async (state, prisma) => {
     const { username, startLoginRequest } = state.data;
+
+    // Throttle repeated login starts per username (brute-force / credential-stuffing).
+    SessionManager.checkLoginRateLimit(username);
 
     const user = await prisma.users.findUnique({
       where: { username },

--- a/packages/mws/src/services/sessions.ts
+++ b/packages/mws/src/services/sessions.ts
@@ -102,6 +102,10 @@ export class SessionManager {
   static readonly LOGIN_WINDOW_MS = 15 * 60_000;   // sliding window
   static readonly LOGIN_MAX_ATTEMPTS = 10;         // starts allowed per window
   static readonly LOGIN_LOCKOUT_MS = 15 * 60_000;  // lock duration once exceeded
+  static readonly LOGIN_MAX_TRACKED = 5000;        // hard cap on tracked usernames (anti-spray)
+
+  /** Number of currently-tracked usernames (exposed for tests / diagnostics). */
+  static get loginTrackedCount(): number { return SessionManager.loginAttempts.size; }
 
   /** Throws a user-facing string if the username is locked out or exceeds the attempt cap. */
   static checkLoginRateLimit(username: string, now: number = Date.now()): void {
@@ -118,19 +122,35 @@ export class SessionManager {
     if (rec.times.length > SessionManager.LOGIN_MAX_ATTEMPTS) {
       rec.lockedUntil = now + SessionManager.LOGIN_LOCKOUT_MS;
       rec.times = [];
-      SessionManager.loginAttempts.set(username, rec);
+      SessionManager.storeAttempt(username, rec, now);
       throw `Too many login attempts. Try again in ${Math.ceil(SessionManager.LOGIN_LOCKOUT_MS / 60_000)} minutes.`;
     }
 
+    SessionManager.storeAttempt(username, rec, now);
+  }
+
+  /**
+   * Store an attempt record and keep the map bounded. The Map's insertion order is used as an
+   * LRU (re-inserting moves a key to the end), so the freshly-touched username is never the one
+   * evicted. Beyond the hard cap we drop stale entries first, then LRU-evict the oldest — this
+   * bounds memory/CPU under a username-spray attack (many distinct fresh usernames in-window,
+   * which the staleness check alone would never reclaim).
+   */
+  private static storeAttempt(username: string, rec: { times: number[]; lockedUntil: number }, now: number): void {
+    SessionManager.loginAttempts.delete(username);
     SessionManager.loginAttempts.set(username, rec);
 
-    // Opportunistic cleanup so the map can't grow unbounded.
-    if (SessionManager.loginAttempts.size > 1000) {
-      for (const [k, v] of SessionManager.loginAttempts) {
-        const last = v.times[v.times.length - 1] ?? 0;
-        if (v.lockedUntil < now && now - last > SessionManager.LOGIN_WINDOW_MS)
-          SessionManager.loginAttempts.delete(k);
-      }
+    if (SessionManager.loginAttempts.size <= SessionManager.LOGIN_MAX_TRACKED) return;
+
+    for (const [k, v] of SessionManager.loginAttempts) {
+      const last = v.times[v.times.length - 1] ?? 0;
+      if (v.lockedUntil < now && now - last > SessionManager.LOGIN_WINDOW_MS)
+        SessionManager.loginAttempts.delete(k);
+    }
+    while (SessionManager.loginAttempts.size > SessionManager.LOGIN_MAX_TRACKED) {
+      const oldest = SessionManager.loginAttempts.keys().next().value;
+      if (oldest === undefined) break;
+      SessionManager.loginAttempts.delete(oldest);
     }
   }
 


### PR DESCRIPTION
Closes #12. Batch 2 of the account-security series.

## Change
`SessionManager.checkLoginRateLimit(username)` called at the top of `POST /login/1`: after a burst of login starts within a sliding window the username is locked out for a cooldown, with a clear "try again in N minutes" message. Defaults (tunable): **10 attempts / 15-min window / 15-min lockout**. In-memory (resets on restart), mirroring the existing password-generation cooldown — no schema change.

## Why username-keyed (not IP)
- Behind **Tailscale Serve** the client IP is always the loopback proxy, so per-IP limiting is meaningless here.
- With **OPAQUE**, a wrong password fails **client-side**, so the server-side signal of an attempt is the `/login/1` start — that's what's counted.
- Tradeoff (documented): a username-keyed lockout can be used to temporarily lock a victim out — acceptable on a tailnet-only deployment; distributed/credential-stuffing across many usernames is noted as residual in `docs/security.md`.

## Verification
- New deterministic unit test (`now` injected, no fake timers): burst → lockout; elapsed → unlock; spread-out attempts never lock. **96/96**.
- Full pre-push gate green (the smoke's single login stays under the cap).
- Docs updated: `security.md` (control + STRIDE + gap), `SDP.md` §6, `TODO.md` (item closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-memory, per-username login rate-limiting to the `POST /login/1` flow, enforcing a sliding window threshold.
  * When the limit is exceeded, users are temporarily locked out and subsequent attempts fail with a message indicating the remaining lockout time.

* **Documentation**
  * Updated security and OWASP posture notes to reflect the new `/login/1` throttling and the revised risk/gaps.

* **Tests**
  * Added Vitest coverage validating attempt thresholds, lockout duration, window reset behavior, and bounded tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->