### PR TITLE
Non-admin landing + ACL editor UI + baseline role assignment (Batch 1)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,6 +50,24 @@ these are polish, not correctness):
       `POST /login/1` (`SessionManager.checkLoginRateLimit`); keyed by username (per-IP is moot
       behind the loopback proxy). Remaining: keep Funnel OFF (standing invariant), consider an
       alert if the listener ever binds non-loopback, and a general per-route rate limit (API4).
+- [ ] **Access-model series (staged PRs off `Alternative-to-react`).** Confirmed decisions:
+      admin content access = least privilege; audit = DB table + admin view; session timeouts =
+      idle 30m / absolute 12h (SSO new-login window 30m).
+  - [x] **Batch 1 — DONE (PR #17 / issue #16):** non-admin landing (`/admin-htmx` → `/wiki/{recipe}`
+        or a friendly "no wikis assigned" 200 page); ACL editor UI in the Recipes/Bags edit modals
+        (wired to `recipe_acl_update` / `bag_acl_update`); `user_create` auto-assigns `USER` and an
+        enabled user must keep ≥1 role. Docs: `security.md` (controls + access-flow diagram),
+        `operations.md` (granting access).
+  - [ ] **Batch 2 — least privilege:** remove the `isAdmin` content bypass in
+        `getRecipeACL`/`getBagACL`; seed `USER`-role ACL on the default wikis + connect the initial
+        admin to `USER`; soft role-count cap (~20; no DB cap exists). **Update `SDP.md` access-control
+        section** + the User→Role→ACL diagram here.
+  - [ ] **Batch 3 — `WIKI_ADMIN` tier:** gate recipe/bag create/delete behind
+        `isAdmin || WIKI_ADMIN || owner` (today any logged-in user can create); document READ =
+        download, WRITE = edit, WIKI_ADMIN = structure/data management.
+  - [ ] **Batch 4 — audit + sessions:** `AuditLog` table + read-only admin view (`audit_list`);
+        emit points across user/role/recipe/bag/login; cookie idle/absolute timeout; SSO login
+        de-dup. **Update `security.md` audit/session section + `SDP.md`.**
 - [ ] Decide FIPS-140-3 scope (recommend: documented non-goal for this deployment) — record it.
 - [ ] Threat model (`docs/security.md`); password-master-key rotation procedure; backup/retention policy.
 - [ ] SBOM / transitive license scan.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -84,6 +84,20 @@ then rotate it with `reset-password` or from the HTMX admin profile.
 Protect `passwords.key` (the password master salt): if it changes, every stored password must
 be reset. See [`security.md`](security.md) for the full posture.
 
+### Granting wiki access to a user
+
+New users get the `USER` role by default. To grant access to a specific wiki:
+
+1. Open **Admin → Recipes** (or **Bags**) and **Edit** the wiki.
+2. In the **Access (roles)** section, **Add role grant**: pick a role and a permission
+   (`READ` = download / read-only, `WRITE` = edit on the server, `ADMIN` = manage the resource),
+   then **Save**.
+3. Assign the user that role from **Admin → Users** if they do not already hold it.
+
+A logged-in non-admin who opens the site lands on their first accessible wiki automatically; one
+with no grant yet sees a "no wikis assigned" page until an admin grants access. An **enabled**
+user must keep at least one role — lock (disable) the account first if you need to strip all roles.
+
 ## 5. Backups
 
 Back up the **entire data folder**, not just `store`:

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,7 +81,21 @@ satisfies all of them.
 - **Authorization (ACL)** — role-based read/write on bags and recipes. A high-severity fix
   corrected `getRecipeACL`/`getBagACL` to read `roles.map(r => r.role_id)` (the code previously
   read an always-`undefined` `role_ids`, so non-admins could only reach resources they owned).
-  See `packages/mws/src/RequestState.ts`.
+  See `packages/mws/src/RequestState.ts`. The grant chain is **User → Role → ACL(role,
+  permission) → Bag/Recipe**, where `permission` is hierarchical `READ < WRITE < ADMIN`
+  (READ = download / read-only, WRITE = edit on the server, ADMIN = manage that resource).
+- **Access-management UI** — admins set, change, and remove role→permission grants from the
+  **Recipes** and **Bags** edit modals ("Access (roles)" section), wired to the existing
+  `recipe_acl_update` / `bag_acl_update` admin keys (full-replace semantics). Previously these
+  keys had no UI and were reachable only by direct API call.
+- **Non-admin landing** — the front door (`GET /`) and the catch-all both funnel to
+  `/admin-htmx`; a logged-in **non-admin** is now redirected from there to their first accessible
+  wiki (`/wiki/{recipe}`) instead of a dead-end 403. A non-admin with no granted wiki sees a
+  friendly "no wikis assigned" page (HTTP 200), not 403. See `packages/mws/src/managers/admin-htmx.ts`.
+- **Baseline role assignment** — `user_create` assigns the `USER` role when the admin selects
+  none, so users are never created role-less (which would deny all default wiki access). An
+  **enabled** user must keep at least one role; only a **disabled (locked)** account may have all
+  roles removed. See `packages/mws/src/managers/admin-users.ts`.
 - **Error contract** — `Streamer.catcher` honours `SendError.status`/`reason` instead of
   blanket-500ing, so an unauthorized request surfaces as `403`, not `500`.
 - **Open-redirect guard** — the login `redirect` parameter accepts only same-origin

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,6 +96,60 @@ satisfies all of them.
   none, so users are never created role-less (which would deny all default wiki access). An
   **enabled** user must keep at least one role; only a **disabled (locked)** account may have all
   roles removed. See `packages/mws/src/managers/admin-users.ts`.
+
+### Access flow
+
+Non-admin front door (landing) and the admin ACL-grant flows, as implemented:
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant AdminHTMX as GET /admin-htmx/
+  participant FFAR as findFirstAccessibleRecipe
+  participant RecipeSave as POST /admin/recipe_create_or_update
+  participant RecipeACL as POST /admin/recipe_acl_update
+  participant BagSave as POST /admin/bag_create_or_update
+  participant BagACL as POST /admin/bag_acl_update
+
+  rect rgba(30, 100, 200, 0.5)
+    note over Browser, FFAR: Non-admin front door (GET / and the catch-all both funnel to /admin-htmx)
+    Browser->>AdminHTMX: GET /admin-htmx/ (non-admin session)
+    AdminHTMX->>FFAR: first recipe where (>=1 bag AND all bags READ-ACL or bag-owner) OR recipe-owner
+    alt wiki accessible
+      FFAR-->>AdminHTMX: recipe_name
+      AdminHTMX-->>Browser: 302 -> {pathPrefix}/wiki/<recipe_name>
+    else no wiki
+      FFAR-->>AdminHTMX: null
+      AdminHTMX-->>Browser: 200 "No wikis assigned yet"
+    end
+  end
+
+  rect rgba(200, 80, 30, 0.5)
+    note over Browser, RecipeACL: Admin saving a Recipe (ACL call only when editing)
+    Browser->>RecipeSave: save recipe (create_only = !isEdit)
+    RecipeSave-->>Browser: 200 OK / error
+    opt isEdit
+      Browser->>RecipeACL: full ACL replace { recipe_name, acl[] }
+      RecipeACL-->>Browser: 200 OK / error
+    end
+  end
+
+  rect rgba(60, 160, 80, 0.5)
+    note over Browser, BagACL: Admin saving a Bag (separate Bags page, ACL call only when editing)
+    Browser->>BagSave: save bag (create_only = !isEdit)
+    BagSave-->>Browser: 200 OK / error
+    opt isEdit
+      Browser->>BagACL: full ACL replace { bag_name, acl[] }
+      BagACL-->>Browser: 200 OK / error
+    end
+  end
+```
+
+> **Least-privilege caveat (current state):** an `isAdmin` user still **bypasses** the content
+> ACL in `getRecipeACL`/`getBagACL`, so admins can read/write every wiki today. Removing that
+> blanket bypass (so admins reach content only via role/ownership) is planned for the next batch —
+> see [`SDP.md`](SDP.md) and [`TODO.md`](TODO.md).
+
 - **Error contract** — `Streamer.catcher` honours `SendError.status`/`reason` instead of
   blanket-500ing, so an unauthorized request surfaces as `403`, not `500`.
 - **Open-redirect guard** — the login `redirect` parameter accepts only same-origin

--- a/packages/mws/src/managers/__tests__/admin-htmx.test.ts
+++ b/packages/mws/src/managers/__tests__/admin-htmx.test.ts
@@ -220,7 +220,7 @@ describe("HtmxAdminManager", () => {
       expect(result.body).toContain("<!DOCTYPE html>");
     });
 
-    it("should return 403 for non-admin users", async () => {
+    it("should land a non-admin on their wiki instead of 403", async () => {
       HtmxAdminManager.defineRoutes(mockRoot);
 
       const mainRoute = capturedRoutes.find(r =>
@@ -233,14 +233,16 @@ describe("HtmxAdminManager", () => {
           user_id: "user-123",
           username: "normaluser",
           isAdmin: false,
-          roles: [],
+          roles: [{ role_id: "r1", role_name: "USER" }],
         },
-      });
+        getBagWhereACL: () => [],
+        engine: { recipes: { findFirst: async () => ({ recipe_name: "moving-house" }) } },
+      } as any);
 
       const result = await mainRoute!.handler(state);
 
-      expect(result.status).toBe(403);
-      expect(result.body).toContain("403 Forbidden");
+      expect(result.status).toBe(302);
+      expect(result.headers.location).toContain("/wiki/moving-house");
     });
 
     it("should emit page accessed event for admin", async () => {
@@ -365,7 +367,32 @@ describe("HtmxAdminManager", () => {
       expect(result.status).toBe(403);
     });
 
-    it("should enforce admin role on main route", async () => {
+    it("should redirect a non-admin to their first accessible wiki", async () => {
+      HtmxAdminManager.defineRoutes(mockRoot);
+
+      const mainRoute = capturedRoutes.find(r =>
+        r.config.path.test("/admin-htmx") &&
+        !r.config.path.toString().includes("profile")
+      );
+
+      const state = createMockState({
+        user: {
+          user_id: "user-123",
+          username: "normaluser",
+          isAdmin: false,
+          roles: [{ role_id: "r1", role_name: "USER" }],
+        },
+        getBagWhereACL: () => [],
+        engine: { recipes: { findFirst: async () => ({ recipe_name: "family wiki" }) } },
+      } as any);
+
+      const result = await mainRoute!.handler(state);
+
+      expect(result.status).toBe(302);
+      expect(result.headers.location).toContain("/wiki/family%20wiki");
+    });
+
+    it("should show a friendly no-wiki page (200) when a non-admin has no access", async () => {
       HtmxAdminManager.defineRoutes(mockRoot);
 
       const mainRoute = capturedRoutes.find(r =>
@@ -380,11 +407,14 @@ describe("HtmxAdminManager", () => {
           isAdmin: false,
           roles: [],
         },
-      });
+        getBagWhereACL: () => [],
+        engine: { recipes: { findFirst: async () => null } },
+      } as any);
 
       const result = await mainRoute!.handler(state);
 
-      expect(result.status).toBe(403);
+      expect(result.status).toBe(200);
+      expect(result.body).toContain("No wikis assigned");
     });
   });
 
@@ -424,9 +454,10 @@ describe("HtmxAdminManager", () => {
 
       HtmxAdminManager.defineRoutes(mockRoot);
 
-      const mainRoute = capturedRoutes.find(r =>
-        r.config.path.test("/admin-htmx") &&
-        !r.config.path.toString().includes("profile")
+      // The main /admin-htmx route now lands non-admins on a wiki; the admin-only
+      // pages (e.g. profile) still emit "forbidden" for a non-admin.
+      const profileRoute = capturedRoutes.find(r =>
+        r.config.path.toString().includes("profile")
       );
 
       const state = createMockState({
@@ -438,7 +469,7 @@ describe("HtmxAdminManager", () => {
         },
       });
 
-      await mainRoute!.handler(state);
+      await profileRoute!.handler(state);
 
       expect(events.length).toBe(1);
       expect(events[0].username).toBe("normaluser");

--- a/packages/mws/src/managers/admin-htmx.ts
+++ b/packages/mws/src/managers/admin-htmx.ts
@@ -197,18 +197,20 @@ export class HtmxAdminManager {
       <body>
         <h1>No wikis assigned yet</h1>
         <p>Your account does not yet have access to any wiki. Please ask an administrator to grant you access.</p>
-        <p><a href="#" id="logout-link">Sign out</a></p>
+        <p><a href="#" id="logout-link" data-path-prefix="${escapeHtml(state.pathPrefix)}">Sign out</a></p>
         <script>
           document.getElementById('logout-link').addEventListener('click', async (e) => {
             e.preventDefault();
+            // pathPrefix is read from a data-* attribute, never inlined into this script
+            // (matches the login page; see security.md "Output encoding").
+            const prefix = e.currentTarget.dataset.pathPrefix || "";
             try {
-              await fetch('${state.pathPrefix}/logout', {
+              await fetch(prefix + '/logout', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'TiddlyWiki' },
-                body: JSON.stringify(undefined)
+                headers: { 'X-Requested-With': 'TiddlyWiki' }
               });
             } catch (err) { /* fall through to redirect */ }
-            window.location.href = '${state.pathPrefix}/login';
+            window.location.href = prefix + '/login';
           });
         </script>
       </body>

--- a/packages/mws/src/managers/admin-htmx.ts
+++ b/packages/mws/src/managers/admin-htmx.ts
@@ -149,6 +149,70 @@ export class HtmxAdminManager {
     `, "utf-8"));
   }
 
+  /**
+   * Find the first wiki (recipe) the current non-admin user may READ, so the
+   * front door can land them on a usable page instead of the admin-only 403.
+   * Mirrors the ACL filter used by StatusManager.index_json (owner OR a bag-level
+   * READ grant via one of the user's roles). Returns the recipe_name or null.
+   */
+  private static async findFirstAccessibleRecipe(state: ServerRequest): Promise<string | null> {
+    const { user_id, roles } = state.user;
+    const role_ids = roles.map(r => r.role_id);
+    const OR = state.getBagWhereACL({ permission: "READ", user_id, role_ids });
+    const recipe = await state.engine.recipes.findFirst({
+      select: { recipe_name: true },
+      where: {
+        OR: [
+          { recipe_bags: { every: { bag: { OR } } } },
+          user_id && { owner_id: { equals: user_id, not: null } },
+        ].filter(truthy),
+      },
+      orderBy: { recipe_name: "asc" },
+    });
+    return recipe?.recipe_name ?? null;
+  }
+
+  /**
+   * Friendly landing for a logged-in non-admin who has no wiki granted yet.
+   * Returns 200 (not 403) with a logout link — they are authenticated, just
+   * not yet assigned access.
+   */
+  private static sendNoWiki(state: ServerRequest) {
+    return state.sendBuffer(200, {
+      "content-type": "text/html; charset=utf-8",
+    }, Buffer.from(`
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>No wikis assigned</title>
+        <style>
+          body { font-family: sans-serif; max-width: 600px; margin: 100px auto; text-align: center; }
+          h1 { color: #555; }
+          a { color: #1565c0; }
+        </style>
+      </head>
+      <body>
+        <h1>No wikis assigned yet</h1>
+        <p>Your account does not yet have access to any wiki. Please ask an administrator to grant you access.</p>
+        <p><a href="#" id="logout-link">Sign out</a></p>
+        <script>
+          document.getElementById('logout-link').addEventListener('click', async (e) => {
+            e.preventDefault();
+            try {
+              await fetch('${state.pathPrefix}/logout', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'TiddlyWiki' },
+                body: JSON.stringify(undefined)
+              });
+            } catch (err) { /* fall through to redirect */ }
+            window.location.href = '${state.pathPrefix}/login';
+          });
+        </script>
+      </body>
+      </html>
+    `, "utf-8"));
+  }
+
   static defineRoutes(root: ServerRoute) {
     // CSS stylesheet route with ETag caching
     root.defineRoute(
@@ -295,9 +359,17 @@ export class HtmxAdminManager {
           }, Buffer.from("Redirecting to login...", "utf-8"));
         }
 
+        // Non-admins do not get the admin Recipes page; land them on their first
+        // accessible wiki instead of a dead-end 403. The front door (GET /) and the
+        // catch-all fallback both funnel here, so this is the single landing chokepoint.
         if (!state.user.isAdmin) {
-          await serverEvents.emitAsync("admin.htmx.page.forbidden", state, state.user.username || "unknown");
-          return HtmxAdminManager.send403(state);
+          const recipeName = await HtmxAdminManager.findFirstAccessibleRecipe(state);
+          if (recipeName) {
+            return state.sendBuffer(302, {
+              "location": `${state.pathPrefix}/wiki/${encodeURIComponent(recipeName)}`,
+            }, Buffer.from("Redirecting to wiki...", "utf-8"));
+          }
+          return HtmxAdminManager.sendNoWiki(state);
         }
 
         await serverEvents.emitAsync("admin.htmx.page.accessed", state, state.user.isAdmin);

--- a/packages/mws/src/managers/admin-htmx.ts
+++ b/packages/mws/src/managers/admin-htmx.ts
@@ -163,7 +163,10 @@ export class HtmxAdminManager {
       select: { recipe_name: true },
       where: {
         OR: [
-          { recipe_bags: { every: { bag: { OR } } } },
+          // `every` alone is vacuously true for a recipe with no bags; require at
+          // least one bag (`some: {}`) so a bag-less recipe is not picked as a landing
+          // target. `every` keeps the read semantics in step with getRecipeACL.
+          { recipe_bags: { some: {}, every: { bag: { OR } } } },
           user_id && { owner_id: { equals: user_id, not: null } },
         ].filter(truthy),
       },

--- a/packages/mws/src/managers/admin-users.ts
+++ b/packages/mws/src/managers/admin-users.ts
@@ -158,9 +158,21 @@ export class UserManager {
     // tailscale_login is unique; blank must be null (not "") so multiple unset users don't collide.
     const tailscale_login = state.data.tailscale_login?.trim() || null;
 
+    // Every enabled user must hold at least one role; default new users to the
+    // baseline "USER" role when the admin selects none, so they are never created
+    // role-less (which would deny them all default wiki access).
+    let effectiveRoleIds = role_ids;
+    if (effectiveRoleIds.length === 0) {
+      const userRole = await prisma.roles.findUnique({
+        where: { role_name: "USER" },
+        select: { role_id: true },
+      });
+      if (userRole) effectiveRoleIds = [userRole.role_id];
+    }
+
     try {
       const user = await prisma.users.create({
-        data: { username, email, nickname, tailscale_login, password: "", roles: { connect: role_ids.map(role_id => ({ role_id })) } },
+        data: { username, email, nickname, tailscale_login, password: "", roles: { connect: effectiveRoleIds.map(role_id => ({ role_id })) } },
         select: { user_id: true, created_at: true }
       });
 
@@ -205,6 +217,18 @@ export class UserManager {
       }
 
       // Allow email/username updates for self
+    }
+
+    // An enabled user must keep at least one role; only a disabled (locked) account
+    // may have all roles removed. This pairs with the lock/disable workflow.
+    if (role_ids.length === 0) {
+      const target = await prisma.users.findUnique({
+        where: { user_id },
+        select: { disabled: true },
+      });
+      if (!target) throw "User not found";
+      if (!target.disabled)
+        throw "An enabled user must have at least one role. Lock (disable) the account first to remove all roles.";
     }
 
     try {

--- a/packages/mws/src/managers/admin-users.ts
+++ b/packages/mws/src/managers/admin-users.ts
@@ -167,7 +167,10 @@ export class UserManager {
         where: { role_name: "USER" },
         select: { role_id: true },
       });
-      if (userRole) effectiveRoleIds = [userRole.role_id];
+      // Fail closed: never create a role-less user. The baseline "USER" role is seeded
+      // at init, so its absence is a misconfiguration the admin must fix first.
+      if (!userRole) throw "Baseline 'USER' role is missing; cannot create a user without a role.";
+      effectiveRoleIds = [userRole.role_id];
     }
 
     try {

--- a/packages/mws/src/templates/htmx-admin-bags.html
+++ b/packages/mws/src/templates/htmx-admin-bags.html
@@ -43,6 +43,12 @@
           <label for="bag-description">Description</label>
           <textarea class="mws-form-textarea" id="bag-description" rows="3"></textarea>
         </div>
+        <div class="mws-form-group" id="bag-acl-group" style="display: none;">
+          <label>Access (roles)</label>
+          <small class="mws-text-muted">Grant roles access to this bag. READ = download / read-only; WRITE = edit on the server; ADMIN = manage this bag.</small>
+          <div id="bag-acl-rows" style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem;"></div>
+          <button type="button" class="mws-btn mws-btn-sm mws-btn-secondary" id="bag-acl-add" style="margin-top: 0.5rem;">Add role grant</button>
+        </div>
       </form>
     </div>
     <div class="mws-modal-footer">
@@ -87,6 +93,54 @@
     const users = indexData?.userListAdmin || indexData?.userListUser || [];
     const user = users.find(u => u.user_id === owner_id);
     return user?.username || 'Unknown';
+  }
+
+  // ---- ACL (role -> permission) editor ----
+  const ACL_PERMISSIONS = ['READ', 'WRITE', 'ADMIN'];
+
+  function aclRoleOptions(selectedRoleId) {
+    const roles = indexData?.roleList || [];
+    return roles.map(r =>
+      `<option value="${escapeHtml(r.role_id)}" ${r.role_id === selectedRoleId ? 'selected' : ''}>${escapeHtml(r.role_name)}</option>`
+    ).join('');
+  }
+
+  function addAclRow(role_id, permission) {
+    const container = document.getElementById('bag-acl-rows');
+    const row = document.createElement('div');
+    row.className = 'mws-acl-row';
+    row.style.cssText = 'display: flex; gap: 0.5rem; align-items: center;';
+    row.innerHTML = `
+      <select class="mws-form-select acl-role" style="flex: 1;">${aclRoleOptions(role_id)}</select>
+      <select class="mws-form-select acl-perm" style="width: 120px;">
+        ${ACL_PERMISSIONS.map(p => `<option value="${p}" ${p === permission ? 'selected' : ''}>${p}</option>`).join('')}
+      </select>
+      <button type="button" class="mws-btn mws-btn-sm mws-btn-danger acl-remove" aria-label="Remove">&times;</button>
+    `;
+    row.querySelector('.acl-remove').addEventListener('click', () => row.remove());
+    container.appendChild(row);
+  }
+
+  function renderAclRows(acl) {
+    const container = document.getElementById('bag-acl-rows');
+    container.innerHTML = '';
+    (acl || []).forEach(entry => addAclRow(entry.role_id, entry.permission));
+  }
+
+  function collectAcl() {
+    const rows = document.querySelectorAll('#bag-acl-rows .mws-acl-row');
+    const seen = new Set();
+    const acl = [];
+    rows.forEach(row => {
+      const role_id = row.querySelector('.acl-role').value;
+      const permission = row.querySelector('.acl-perm').value;
+      const key = role_id + '|' + permission;
+      if (role_id && !seen.has(key)) {
+        seen.add(key);
+        acl.push({ role_id, permission });
+      }
+    });
+    return acl;
   }
 
   function renderBags() {
@@ -152,11 +206,17 @@
       document.getElementById('bag-name').value = currentBag.bag_name;
       document.getElementById('bag-name').readOnly = true;
       document.getElementById('bag-description').value = currentBag.description || '';
+
+      // ACL only applies to an existing bag; show + populate when editing.
+      document.getElementById('bag-acl-group').style.display = 'block';
+      renderAclRows(currentBag.acl);
     } else {
       currentBag = null;
       title.textContent = 'Create Bag';
       form.reset();
       document.getElementById('bag-name').readOnly = false;
+      document.getElementById('bag-acl-group').style.display = 'none';
+      document.getElementById('bag-acl-rows').innerHTML = '';
     }
 
     modal.classList.add('mws-show');
@@ -170,6 +230,9 @@
       showToast('Bag name is required', 'error');
       return;
     }
+
+    const isEdit = !!currentBag;
+    const aclEntries = isEdit ? collectAcl() : null;
 
     try {
       const response = await fetch(pathPrefix + '/admin/bag_create_or_update', {
@@ -198,7 +261,27 @@
         throw new Error(errorMsg);
       }
 
-      showToast(`Bag ${currentBag ? 'updated' : 'created'} successfully`, 'success');
+      // Persist ACL grants (full replace) when editing an existing bag.
+      if (isEdit) {
+        const aclResponse = await fetch(pathPrefix + '/admin/bag_acl_update', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'TiddlyWiki',
+            'Referer': window.location.href
+          },
+          body: JSON.stringify({ bag_name: name, acl: aclEntries })
+        });
+        if (!aclResponse.ok) {
+          const text = await aclResponse.text();
+          let errorMsg = 'Bag saved, but updating access failed';
+          try { const data = JSON.parse(text); if (data.reason) errorMsg = data.reason; }
+          catch (e) { if (text && text.length < 200) errorMsg = text; }
+          throw new Error(errorMsg);
+        }
+      }
+
+      showToast(`Bag ${isEdit ? 'updated' : 'created'} successfully`, 'success');
       closeBagModal();
       loadIndex();
     } catch (error) {
@@ -256,6 +339,7 @@
     document.getElementById('bag-modal-close').addEventListener('click', closeBagModal);
     document.getElementById('bag-cancel-btn').addEventListener('click', closeBagModal);
     document.getElementById('bag-save-btn').addEventListener('click', saveBag);
+    document.getElementById('bag-acl-add').addEventListener('click', () => addAclRow('', 'READ'));
 
     document.getElementById('bag-modal').addEventListener('click', (e) => {
       if (e.target.id === 'bag-modal') closeBagModal();

--- a/packages/mws/src/templates/htmx-admin-recipes.html
+++ b/packages/mws/src/templates/htmx-admin-recipes.html
@@ -67,6 +67,12 @@
           <textarea class="mws-form-textarea" id="recipe-bags" rows="5" placeholder="system&#10;+my-bag&#10;another-bag"></textarea>
           <small class="mws-text-muted">Prefix bag name with + to include ACL</small>
         </div>
+        <div class="mws-form-group" id="recipe-acl-group" style="display: none;">
+          <label>Access (roles)</label>
+          <small class="mws-text-muted">Grant roles access to this recipe. READ = download / read-only; WRITE = edit on the server; ADMIN = manage this recipe.</small>
+          <div id="recipe-acl-rows" style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem;"></div>
+          <button type="button" class="mws-btn mws-btn-sm mws-btn-secondary" id="recipe-acl-add" style="margin-top: 0.5rem;">Add role grant</button>
+        </div>
       </form>
     </div>
     <div class="mws-modal-footer">
@@ -117,6 +123,54 @@
   function getBagName(bag_id) {
     const bag = indexData?.bagList?.find(b => b.bag_id === bag_id);
     return bag?.bag_name || '?';
+  }
+
+  // ---- ACL (role -> permission) editor ----
+  const ACL_PERMISSIONS = ['READ', 'WRITE', 'ADMIN'];
+
+  function aclRoleOptions(selectedRoleId) {
+    const roles = indexData?.roleList || [];
+    return roles.map(r =>
+      `<option value="${escapeHtml(r.role_id)}" ${r.role_id === selectedRoleId ? 'selected' : ''}>${escapeHtml(r.role_name)}</option>`
+    ).join('');
+  }
+
+  function addAclRow(role_id, permission) {
+    const container = document.getElementById('recipe-acl-rows');
+    const row = document.createElement('div');
+    row.className = 'mws-acl-row';
+    row.style.cssText = 'display: flex; gap: 0.5rem; align-items: center;';
+    row.innerHTML = `
+      <select class="mws-form-select acl-role" style="flex: 1;">${aclRoleOptions(role_id)}</select>
+      <select class="mws-form-select acl-perm" style="width: 120px;">
+        ${ACL_PERMISSIONS.map(p => `<option value="${p}" ${p === permission ? 'selected' : ''}>${p}</option>`).join('')}
+      </select>
+      <button type="button" class="mws-btn mws-btn-sm mws-btn-danger acl-remove" aria-label="Remove">&times;</button>
+    `;
+    row.querySelector('.acl-remove').addEventListener('click', () => row.remove());
+    container.appendChild(row);
+  }
+
+  function renderAclRows(acl) {
+    const container = document.getElementById('recipe-acl-rows');
+    container.innerHTML = '';
+    (acl || []).forEach(entry => addAclRow(entry.role_id, entry.permission));
+  }
+
+  function collectAcl() {
+    const rows = document.querySelectorAll('#recipe-acl-rows .mws-acl-row');
+    const seen = new Set();
+    const acl = [];
+    rows.forEach(row => {
+      const role_id = row.querySelector('.acl-role').value;
+      const permission = row.querySelector('.acl-perm').value;
+      const key = role_id + '|' + permission;
+      if (role_id && !seen.has(key)) {
+        seen.add(key);
+        acl.push({ role_id, permission });
+      }
+    });
+    return acl;
   }
 
   function renderRecipes() {
@@ -237,11 +291,17 @@
         return rb.with_acl ? `+${name}` : name;
       }).join('\n') || '';
       document.getElementById('recipe-bags').value = bags;
+
+      // ACL only applies to an existing recipe; show + populate when editing.
+      document.getElementById('recipe-acl-group').style.display = 'block';
+      renderAclRows(currentRecipe.acl);
     } else {
       currentRecipe = null;
       title.textContent = 'Create Recipe';
       form.reset();
       document.getElementById('recipe-name').readOnly = false;
+      document.getElementById('recipe-acl-group').style.display = 'none';
+      document.getElementById('recipe-acl-rows').innerHTML = '';
     }
 
     modal.classList.add('mws-show');
@@ -267,6 +327,9 @@
       const bag_name = with_acl ? line.substring(1) : line;
       return { bag_name, with_acl };
     });
+
+    const isEdit = !!currentRecipe;
+    const aclEntries = isEdit ? collectAcl() : null;
 
     try {
       const response = await fetch(pathPrefix + '/admin/recipe_create_or_update', {
@@ -301,7 +364,27 @@
         throw new Error(errorMsg);
       }
 
-      showToast(`Recipe ${currentRecipe ? 'updated' : 'created'} successfully`, 'success');
+      // Persist ACL grants (full replace) when editing an existing recipe.
+      if (isEdit) {
+        const aclResponse = await fetch(pathPrefix + '/admin/recipe_acl_update', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'TiddlyWiki',
+            'Referer': window.location.href
+          },
+          body: JSON.stringify({ recipe_name: name, acl: aclEntries })
+        });
+        if (!aclResponse.ok) {
+          const text = await aclResponse.text();
+          let errorMsg = 'Recipe saved, but updating access failed';
+          try { const data = JSON.parse(text); if (data.reason) errorMsg = data.reason; }
+          catch (e) { if (text && text.length < 200) errorMsg = text; }
+          throw new Error(errorMsg);
+        }
+      }
+
+      showToast(`Recipe ${isEdit ? 'updated' : 'created'} successfully`, 'success');
       closeRecipeModal();
       loadIndex();
     } catch (error) {
@@ -360,6 +443,7 @@
     document.getElementById('recipe-modal-close').addEventListener('click', closeRecipeModal);
     document.getElementById('recipe-cancel-btn').addEventListener('click', closeRecipeModal);
     document.getElementById('recipe-save-btn').addEventListener('click', saveRecipe);
+    document.getElementById('recipe-acl-add').addEventListener('click', () => addAclRow('', 'READ'));
 
     // Close modal on outside click
     document.getElementById('recipe-modal').addEventListener('click', (e) => {


### PR DESCRIPTION
Refs #16. First PR in the access-model series.

## What

- **Non-admin landing** (`managers/admin-htmx.ts`): `/admin-htmx` (the chokepoint the front door and catch-all both funnel into) redirects a logged-in **non-admin** to their first accessible wiki (`/wiki/{recipe}`) instead of a dead-end 403. A non-admin with no granted wiki gets a friendly "no wikis assigned" page (HTTP 200) with a sign-out link.
- **ACL editor UI** (`templates/htmx-admin-recipes.html`, `htmx-admin-bags.html`): an "Access (roles)" section in the edit modals lists current `{role, permission}` grants with add/remove and submits the full set to the existing `recipe_acl_update` / `bag_acl_update` keys (full-replace semantics). These pages are admin-only, so no extra read-only gating is needed.
- **Baseline role** (`managers/admin-users.ts`): `user_create` assigns the `USER` role when none is selected; `user_update` blocks clearing all roles for an **enabled** user while allowing it for a **disabled (locked)** account.

Permission semantics shown in the UI/docs: `READ` = download / read-only, `WRITE` = edit on the server, `ADMIN` = manage the resource.

## Why

The React→HTMX cutover never reimplemented user-facing access: non-admins had no landing (403 loop) and there was no UI to grant ACLs. See #16.

## Tests / checks

- `npm run build` ✅ · `npm run test:unit` ✅ (104 pass; the obsolete "non-admin → 403 on /admin-htmx" assertions were updated to the new landing behaviour, plus a no-wiki-page test).
- `mws-cutover-check` ✅ 0 failures · `openapi-coverage` ✅ 0 failures (no new routes/keys).

## Notes for review

- The role-rule guards live in the `admin()`-wrapped handlers; the repo has no admin-users unit harness, so those are covered by the headless smoke + live verification (consistent with existing layout) rather than new unit mocks.

## Scope / follow-ups (later PRs)

Least-privilege admin content access, the `WIKI_ADMIN` data-management tier, and audit logging + session lifecycle are deliberately out of scope here and tracked for subsequent batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role→permission (ACL) editors to admin modals for Recipes and Bags.
  * Added a “no wikis assigned yet” landing page for users without accessible wikis, including a logout option.
  * Automatically assigns a default **USER** role during user creation when no roles are provided.

* **Bug Fixes**
  * Non-admin users no longer hit access-denied on the wiki admin entry point; they’re redirected to their first accessible wiki (or the no-wikis page).

* **Documentation**
  * Updated guides covering granting wiki access, role/permission grant behavior, and the access flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->