### PR TITLE
User home page + working logout under Tailscale SSO (Batch 5)

### DIFF
--- a/.claude/skills/openapi-coverage/check.sh
+++ b/.claude/skills/openapi-coverage/check.sh
@@ -157,6 +157,8 @@ REGEX_DOC_PATHS=(
   "/\$cache/{plugin}/plugin.js"    # cache.ts  /^\/\$cache\/(.*)\/plugin\.js$/
   "/mws-docs/{path}"               # tw-routes.ts  ^/mws-docs(/|$)
   "/login"                         # admin-htmx.ts  /^\/login$/
+  "/home"                          # admin-htmx.ts  /^\/home$/
+  "/resume-sso"                    # admin-htmx.ts  /^\/resume-sso$/
   "/admin-htmx"                    # admin-htmx.ts  /^\/admin-htmx\/?$/
   "/admin-htmx/bags"               # admin-htmx.ts
   "/admin-htmx/plugins"            # admin-htmx.ts
@@ -184,6 +186,8 @@ REGEX_SRC_KNOWN=(
   '/^\/wiki\/(.*)$/'                       # wiki-index.ts               -> /wiki/{recipe_name}
   '/^\/\$cache\/(.*)\/plugin\.js$/'        # cache.ts                    -> /$cache/{plugin}/plugin.js
   '/^\/login$/'                            # admin-htmx.ts               -> /login
+  '/^\/home$/'                             # admin-htmx.ts               -> /home
+  '/^\/resume-sso$/'                       # admin-htmx.ts               -> /resume-sso
   '/^\/admin-htmx\/?$/'                    # admin-htmx.ts               -> /admin-htmx
   '/^\/admin-htmx\/bags$/'                 # admin-htmx.ts
   '/^\/admin-htmx\/plugins$/'              # admin-htmx.ts

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -68,6 +68,14 @@ these are polish, not correctness):
   - [ ] **Batch 4 — audit + sessions:** `AuditLog` table + read-only admin view (`audit_list`);
         emit points across user/role/recipe/bag/login; cookie idle/absolute timeout; SSO login
         de-dup. **Update `security.md` audit/session section + `SDP.md`.**
+  - [x] **Batch 5 — DONE (PR #19 / issue #18):** user home page (`/home`) listing the wikis a
+        user can reach (reference wikis open in a new tab), with a working logout and a manage-wikis
+        link when permitted; root dispatch by role (anon→login, admin→admin, user→/home); logout
+        sets a short-lived `mws_no_sso` marker honoured before SSO so logout/persona-switch works,
+        with a `/resume-sso` short-cut + login-page button. Docs: `security.md`, `operations.md`.
+  - [ ] **Batch 6 — generic in-wiki home button:** inject the `🏠 MWS home` button server-side
+        into served wikis (skip reference wikis); drop the hand-coded link from the moving-house-app
+        seed (separate repo). Follows Batch 5.
 - [ ] Decide FIPS-140-3 scope (recommend: documented non-goal for this deployment) — record it.
 - [ ] Threat model (`docs/security.md`); password-master-key rotation procedure; backup/retention policy.
 - [ ] SBOM / transitive license scan.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -132,3 +132,15 @@ Family members can be logged in automatically by their Tailscale identity — no
 
 Unmapped identities are denied (no auto-provision); a disabled account is rejected; and password
 login still works (admin/CLI/non-tailnet). See [`security.md`](security.md) for the trust model.
+
+### Signing out / switching persona under SSO
+
+Because SSO authenticates from the identity header on every request, a plain logout would
+re-authenticate instantly. So **logout** (the button on `/home` or the admin frame) sets a
+short-lived `mws_no_sso` marker that suppresses SSO for ~5 minutes, landing you on `/login`:
+
+- To **sign in as a different persona**, enter that user's username/password on `/login` — the
+  password session takes precedence and the marker is cleared.
+- To **come back as yourself immediately** (skip the wait), click **"Log in with Tailscale (SSO)"**
+  on the login page (`GET /resume-sso`) — it clears the marker and SSO re-resolves.
+- Otherwise SSO simply resumes automatically once the marker expires.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -94,9 +94,10 @@ New users get the `USER` role by default. To grant access to a specific wiki:
    then **Save**.
 3. Assign the user that role from **Admin → Users** if they do not already hold it.
 
-A logged-in non-admin who opens the site lands on their first accessible wiki automatically; one
-with no grant yet sees a "no wikis assigned" page until an admin grants access. An **enabled**
-user must keep at least one role — lock (disable) the account first if you need to strip all roles.
+A logged-in non-admin who opens the site lands on their **home page** (`/home`), which lists the
+wikis they can reach; if none are granted yet it shows a "contact an administrator" message until
+an admin grants access. An **enabled** user must keep at least one role — lock (disable) the
+account first if you need to strip all roles.
 
 ## 5. Backups
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -78,6 +78,18 @@ satisfies all of them.
   client-supplied `Tailscale-*` headers and injects the verified identity), and **Funnel is OFF**
   (public requests carry no header → fall through to password). **Deny-unless-mapped** (no
   auto-provision); disabled users are rejected. See `SessionManager.resolveTailscaleSSO`.
+- **Logout under SSO (suppress marker)** — because SSO is stateless, clearing the session cookie
+  alone would let the very next request re-authenticate from the identity header, so logout could
+  never "stick." Logout therefore sets a short-lived (~5 min) `mws_no_sso` cookie (HttpOnly,
+  SameSite=Strict, Secure under TLS) that `parseIncomingRequest` honours **before** SSO, landing
+  the user on `/login` so they can sign in as a different persona. A valid session cookie still
+  takes precedence (password login wins), and the marker is cleared on login. It can only *force*
+  password login (more friction, never less) and is TTL-bounded; `GET /resume-sso` clears it to
+  resume SSO immediately. See `services/sessions.ts`.
+- **User home page (`/home`)** — a logged-in non-admin lands on a standalone page listing the wikis
+  they may READ (reference/doc wikis open in a new tab), with a logout control and — when permitted
+  — a manage-wikis link; an admin keeps the admin UI. Replaces the earlier dead-end redirect and
+  the no-wiki page. See `managers/admin-htmx.ts`.
 - **Authorization (ACL)** — role-based read/write on bags and recipes. A high-severity fix
   corrected `getRecipeACL`/`getBagACL` to read `roles.map(r => r.role_id)` (the code previously
   read an always-`undefined` `role_ids`, so non-admins could only reach resources they owned).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -660,15 +660,48 @@ paths:
   /:
     get:
       tags: [Admin UI]
-      summary: Front door — redirect to the HTMX admin
+      summary: Front door — role-based redirect
       description: |
-        Exact `/` redirects (`302`) to `/admin-htmx`. The unmatched-GET fallback
-        (`GET /*`, regex `^/.*` in `managers/index.ts`) performs the same redirect, so any
-        otherwise-unhandled GET path lands on the admin home (which gates auth).
+        Exact `/` redirects (`302`) by role: anonymous → `/login`; admin → `/admin-htmx`;
+        a normal user → `/home` (their wiki list). The unmatched-GET fallback
+        (`GET /*`, regex `^/.*` in `managers/index.ts`) redirects to `/admin-htmx`, which
+        itself routes non-admins on to `/home`.
       security: []
       responses:
         '302':
-          description: Redirect to `/admin-htmx`.
+          description: Redirect to `/login`, `/admin-htmx`, or `/home` per role.
+          headers:
+            Location: { schema: { type: string } }
+
+  /home:
+    get:
+      tags: [Admin UI]
+      summary: User home page — the wikis you can reach
+      description: |
+        Standalone page (not the admin frame) listing the wikis the signed-in user can READ,
+        with a logout control and — when permitted — a "Manage wikis" link. Reference/doc wikis
+        open in a new tab; task wikis in the same tab. If the user has no wiki, shows a
+        "contact an administrator" message. Redirects to `/login` if unauthenticated.
+      responses:
+        '200':
+          description: User home HTML page.
+          content:
+            text/html:
+              schema: { type: string }
+        '302': { description: Redirect to `/login`. }
+
+  /resume-sso:
+    get:
+      tags: [Admin UI]
+      summary: Resume Tailscale SSO after logout
+      description: |
+        Clears the short-lived `mws_no_sso` suppress marker that logout sets, then `302`s to
+        `/` so the next request re-authenticates via Tailscale SSO. Offered as a "Log in with
+        Tailscale" short-cut on the login page when SSO is enabled.
+      security: []
+      responses:
+        '302':
+          description: Redirect to `/` (SSO re-resolves).
           headers:
             Location: { schema: { type: string } }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -733,15 +733,14 @@ paths:
     get:
       tags: [Admin UI]
       summary: HTMX admin home (Recipes)
-      description: Default admin page. Redirects to `/login` if unauthenticated; `403` if not an admin.
+      description: Default admin page. Redirects to `/login` if unauthenticated; to `/home` if not an admin.
       responses:
         '200':
           description: Admin Recipes page (HTML).
           content:
             text/html:
               schema: { type: string }
-        '302': { description: Redirect to `/login`. }
-        '403': { $ref: '#/components/responses/HtmlError' }
+        '302': { description: Redirect to `/login` (unauthenticated) or `/home` (non-admin). }
 
   /admin-htmx/bags:
     get:

--- a/packages/mws/src/managers/__tests__/admin-htmx.test.ts
+++ b/packages/mws/src/managers/__tests__/admin-htmx.test.ts
@@ -220,12 +220,13 @@ describe("HtmxAdminManager", () => {
       expect(result.body).toContain("<!DOCTYPE html>");
     });
 
-    it("should land a non-admin on their wiki instead of 403", async () => {
+    it("should redirect a non-admin to the user home page instead of 403", async () => {
       HtmxAdminManager.defineRoutes(mockRoot);
 
       const mainRoute = capturedRoutes.find(r =>
         r.config.path.test("/admin-htmx") &&
-        !r.config.path.toString().includes("profile")
+        !r.config.path.toString().includes("profile") &&
+        !r.config.path.test("/home")
       );
 
       const state = createMockState({
@@ -235,14 +236,12 @@ describe("HtmxAdminManager", () => {
           isAdmin: false,
           roles: [{ role_id: "r1", role_name: "USER" }],
         },
-        getBagWhereACL: () => [],
-        engine: { recipes: { findFirst: async () => ({ recipe_name: "moving-house" }) } },
       } as any);
 
       const result = await mainRoute!.handler(state);
 
       expect(result.status).toBe(302);
-      expect(result.headers.location).toContain("/wiki/moving-house");
+      expect(result.headers.location).toContain("/home");
     });
 
     it("should emit page accessed event for admin", async () => {
@@ -367,12 +366,13 @@ describe("HtmxAdminManager", () => {
       expect(result.status).toBe(403);
     });
 
-    it("should redirect a non-admin to their first accessible wiki", async () => {
+    it("should redirect a non-admin from /admin-htmx to the user home page", async () => {
       HtmxAdminManager.defineRoutes(mockRoot);
 
       const mainRoute = capturedRoutes.find(r =>
         r.config.path.test("/admin-htmx") &&
-        !r.config.path.toString().includes("profile")
+        !r.config.path.toString().includes("profile") &&
+        !r.config.path.test("/home")
       );
 
       const state = createMockState({
@@ -382,39 +382,71 @@ describe("HtmxAdminManager", () => {
           isAdmin: false,
           roles: [{ role_id: "r1", role_name: "USER" }],
         },
-        getBagWhereACL: () => [],
-        engine: { recipes: { findFirst: async () => ({ recipe_name: "family wiki" }) } },
       } as any);
 
       const result = await mainRoute!.handler(state);
 
       expect(result.status).toBe(302);
-      expect(result.headers.location).toContain("/wiki/family%20wiki");
+      expect(result.headers.location).toContain("/home");
+    });
+  });
+
+  describe("User Home Route (/home)", () => {
+    const homeRoute = () => capturedRoutes.find(r => r.config.path.test("/home"));
+
+    it("redirects to /login when unauthenticated", async () => {
+      HtmxAdminManager.defineRoutes(mockRoot);
+      const state = createMockState({
+        user: undefined,
+        okUser: function () { throw new Error("Not authenticated"); },
+      } as any);
+      const result = await homeRoute()!.handler(state);
+      expect(result.status).toBe(302);
+      expect(result.headers.location).toContain("/login");
     });
 
-    it("should show a friendly no-wiki page (200) when a non-admin has no access", async () => {
+    it("lists accessible wikis, opening reference wikis in a new tab", async () => {
       HtmxAdminManager.defineRoutes(mockRoot);
-
-      const mainRoute = capturedRoutes.find(r =>
-        r.config.path.test("/admin-htmx") &&
-        !r.config.path.toString().includes("profile")
-      );
-
       const state = createMockState({
-        user: {
-          user_id: "user-123",
-          username: "normaluser",
-          isAdmin: false,
-          roles: [],
-        },
+        user: { user_id: "u1", username: "normaluser", isAdmin: false, roles: [{ role_id: "r1", role_name: "USER" }] },
         getBagWhereACL: () => [],
-        engine: { recipes: { findFirst: async () => null } },
+        engine: { recipes: { findMany: async () => [{ recipe_name: "moving-house" }, { recipe_name: "docs" }] } },
       } as any);
-
-      const result = await mainRoute!.handler(state);
-
+      const result = await homeRoute()!.handler(state);
       expect(result.status).toBe(200);
-      expect(result.body).toContain("No wikis assigned");
+      expect(result.body).toContain("/wiki/moving-house");
+      expect(result.body).toContain("/wiki/docs");
+      // The reference wiki "docs" opens in a new tab; the task wiki does not.
+      expect(result.body).toMatch(/\/wiki\/docs"[^>]*target="_blank"/);
+      expect(result.body).not.toMatch(/\/wiki\/moving-house"[^>]*target="_blank"/);
+    });
+
+    it("shows a contact-admin message when the user has no wiki", async () => {
+      HtmxAdminManager.defineRoutes(mockRoot);
+      const state = createMockState({
+        user: { user_id: "u1", username: "normaluser", isAdmin: false, roles: [] },
+        getBagWhereACL: () => [],
+        engine: { recipes: { findMany: async () => [] } },
+      } as any);
+      const result = await homeRoute()!.handler(state);
+      expect(result.status).toBe(200);
+      expect(result.body).toContain("ask an administrator");
+    });
+  });
+
+  describe("Resume SSO Route (/resume-sso)", () => {
+    it("clears the suppress marker and redirects to the front door", async () => {
+      HtmxAdminManager.defineRoutes(mockRoot);
+      const cleared: Array<{ name: string; value: string }> = [];
+      const route = capturedRoutes.find(r => r.config.path.test("/resume-sso"));
+      const state = createMockState({
+        expectSecure: true,
+        setCookie: (name: string, value: string) => { cleared.push({ name, value }); },
+      } as any);
+      const result = await route!.handler(state);
+      expect(result.status).toBe(302);
+      expect(result.headers.location).toMatch(/\/$/);
+      expect(cleared.some(c => c.name === "mws_no_sso" && c.value === "")).toBe(true);
     });
   });
 

--- a/packages/mws/src/managers/admin-htmx.ts
+++ b/packages/mws/src/managers/admin-htmx.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import { ServerRoute, dist_resolve, dist_require_resolve, ServerRequest } from "@tiddlywiki/server";
 import { serverEvents } from "@tiddlywiki/events";
 import { createHash } from "crypto";
+import { REFERENCE_RECIPES } from "../services/reference-recipes";
 
 declare module "@tiddlywiki/events" {
   interface ServerEventsMap {
@@ -93,6 +94,13 @@ export class HtmxAdminManager {
     let html = await readFile(templatePath, "utf-8");
     html = html.replace(/\{\{pathPrefix\}\}/g, escapeHtml(pathPrefix));
     html = html.replace(/\{\{redirect\}\}/g, escapeHtml(redirect));
+    // Offer the "Log in with Tailscale (SSO)" short-cut only when SSO is enabled.
+    // It clears the logout suppress marker (GET /resume-sso) so SSO resumes at once.
+    // A plain link (not inlined JS); pathPrefix is attribute-escaped.
+    const ssoButton = process.env.MWS_TAILSCALE_SSO === "1"
+      ? `<p class="mws-login-sso"><a class="mws-btn" href="${escapeHtml(pathPrefix)}/resume-sso">Log in with Tailscale (SSO)</a></p>`
+      : "";
+    html = html.replace(/\{\{ssoButton\}\}/g, ssoButton);
     return html;
   }
 
@@ -150,67 +158,96 @@ export class HtmxAdminManager {
   }
 
   /**
-   * Find the first wiki (recipe) the current non-admin user may READ, so the
-   * front door can land them on a usable page instead of the admin-only 403.
-   * Mirrors the ACL filter used by StatusManager.index_json (owner OR a bag-level
-   * READ grant via one of the user's roles). Returns the recipe_name or null.
+   * List the wikis (recipe names) the current user may READ, for the user home
+   * page. Mirrors the ACL filter used by StatusManager.index_json: an admin sees
+   * all recipes; otherwise it is owner OR a bag-level READ grant via one of the
+   * user's roles (at least one bag, all bags readable). Sorted by name.
    */
-  private static async findFirstAccessibleRecipe(state: ServerRequest): Promise<string | null> {
-    const { user_id, roles } = state.user;
+  private static async findAccessibleRecipes(state: ServerRequest): Promise<string[]> {
+    const { user_id, roles, isAdmin } = state.user;
     const role_ids = roles.map(r => r.role_id);
     const OR = state.getBagWhereACL({ permission: "READ", user_id, role_ids });
-    const recipe = await state.engine.recipes.findFirst({
+    const recipes = await state.engine.recipes.findMany({
       select: { recipe_name: true },
-      where: {
+      where: isAdmin ? undefined : {
         OR: [
-          // `every` alone is vacuously true for a recipe with no bags; require at
-          // least one bag (`some: {}`) so a bag-less recipe is not picked as a landing
-          // target. `every` keeps the read semantics in step with getRecipeACL.
+          // `every` is vacuously true for a recipe with no bags; require at least
+          // one bag (`some: {}`). `every` keeps the read semantics in step with
+          // getRecipeACL.
           { recipe_bags: { some: {}, every: { bag: { OR } } } },
           user_id && { owner_id: { equals: user_id, not: null } },
         ].filter(truthy),
       },
       orderBy: { recipe_name: "asc" },
     });
-    return recipe?.recipe_name ?? null;
+    return recipes.map(r => r.recipe_name);
   }
 
   /**
-   * Friendly landing for a logged-in non-admin who has no wiki granted yet.
-   * Returns 200 (not 403) with a logout link — they are authenticated, just
-   * not yet assigned access.
+   * The user home page: a standalone (non-admin-frame) page listing the wikis the
+   * user can reach, with a logout button and — when permitted — a link to manage
+   * wikis. Reference/doc wikis open in a new tab; task wikis open in the same tab.
+   * If the user has no wiki yet, shows a "contact an administrator" message
+   * (this replaces the former no-wiki page).
    */
-  private static sendNoWiki(state: ServerRequest) {
+  private static renderUserHome(state: ServerRequest, recipeNames: string[]) {
+    const prefix = state.pathPrefix;
+    // Manage-wikis is admin-only today; Batch 3 extends this to WIKI_ADMIN.
+    const canManage = state.user.isAdmin;
+
+    const list = recipeNames.map(name => {
+      const ref = REFERENCE_RECIPES.has(name);
+      const attrs = ref ? ' target="_blank" rel="noopener"' : '';
+      const tag = ref ? ' <span class="ref">reference ↗</span>' : '';
+      return `<li><a href="${escapeHtml(prefix)}/wiki/${encodeURIComponent(name)}"${attrs}>${escapeHtml(name)}</a>${tag}</li>`;
+    }).join('\n');
+
+    const body = recipeNames.length
+      ? `<p>Choose a wiki:</p>\n<ul class="wikis">\n${list}\n</ul>`
+      : `<p>Your account does not yet have access to any wiki. Please ask an administrator to grant you access.</p>`;
+
+    const manage = canManage
+      ? `<p class="manage"><a href="${escapeHtml(prefix)}/admin-htmx">Manage wikis</a></p>`
+      : '';
+
     return state.sendBuffer(200, {
       "content-type": "text/html; charset=utf-8",
     }, Buffer.from(`
       <!DOCTYPE html>
       <html>
       <head>
-        <title>No wikis assigned</title>
+        <meta charset="utf-8">
+        <title>MWS — Your wikis</title>
         <style>
-          body { font-family: sans-serif; max-width: 600px; margin: 100px auto; text-align: center; }
-          h1 { color: #555; }
+          body { font-family: sans-serif; max-width: 640px; margin: 80px auto; padding: 0 1rem; }
+          h1 { color: #333; }
+          ul.wikis { list-style: none; padding: 0; }
+          ul.wikis li { margin: .4em 0; padding: .6em .8em; background: #eef3ff; border: 1px solid #c7d6f0; border-radius: 6px; }
+          ul.wikis a { color: #1565c0; text-decoration: none; font-weight: bold; }
+          .ref { color: #666; font-weight: normal; font-size: .85em; }
+          .manage { margin-top: 1.5em; }
           a { color: #1565c0; }
+          .signout { margin-top: 2em; border-top: 1px solid #eee; padding-top: 1em; }
         </style>
       </head>
       <body>
-        <h1>No wikis assigned yet</h1>
-        <p>Your account does not yet have access to any wiki. Please ask an administrator to grant you access.</p>
-        <p><a href="#" id="logout-link" data-path-prefix="${escapeHtml(state.pathPrefix)}">Sign out</a></p>
+        <h1>Your wikis</h1>
+        ${body}
+        ${manage}
+        <p class="signout"><a href="#" id="logout-link" data-path-prefix="${escapeHtml(prefix)}">Sign out</a></p>
         <script>
           document.getElementById('logout-link').addEventListener('click', async (e) => {
             e.preventDefault();
             // pathPrefix is read from a data-* attribute, never inlined into this script
             // (matches the login page; see security.md "Output encoding").
-            const prefix = e.currentTarget.dataset.pathPrefix || "";
+            const p = e.currentTarget.dataset.pathPrefix || "";
             try {
-              await fetch(prefix + '/logout', {
+              await fetch(p + '/logout', {
                 method: 'POST',
                 headers: { 'X-Requested-With': 'TiddlyWiki' }
               });
             } catch (err) { /* fall through to redirect */ }
-            window.location.href = prefix + '/login';
+            window.location.href = p + '/login';
           });
         </script>
       </body>
@@ -349,6 +386,50 @@ export class HtmxAdminManager {
       }
     );
 
+    // User home page — lists the wikis the signed-in user can reach, with logout.
+    // Any authenticated user (admin or not); non-admins are routed here by the
+    // front door and the /admin-htmx redirect.
+    root.defineRoute(
+      {
+        path: /^\/home$/,
+        method: ["GET"],
+      },
+      async (state) => {
+        try {
+          state.okUser();
+        } catch (error) {
+          return state.sendBuffer(302, {
+            "location": `${state.pathPrefix}/login?redirect=${encodeURIComponent(state.url)}`,
+          }, Buffer.from("Redirecting to login...", "utf-8"));
+        }
+        const recipes = await HtmxAdminManager.findAccessibleRecipes(state);
+        return HtmxAdminManager.renderUserHome(state, recipes);
+      }
+    );
+
+    // Resume Tailscale SSO: clears the short-lived `mws_no_sso` suppress marker that
+    // logout sets, so the next request re-authenticates via SSO immediately (the
+    // login page offers this as a "Log in with Tailscale" short-cut). Fixed redirect
+    // to the front door — no open-redirect.
+    root.defineRoute(
+      {
+        path: /^\/resume-sso$/,
+        method: ["GET"],
+      },
+      async (state) => {
+        state.setCookie("mws_no_sso", "", {
+          httpOnly: true,
+          path: state.pathPrefix + "/",
+          expires: new Date(0),
+          secure: state.expectSecure,
+          sameSite: "Strict",
+        });
+        return state.sendBuffer(302, {
+          "location": `${state.pathPrefix}/`,
+        }, Buffer.from("Resuming SSO...", "utf-8"));
+      }
+    );
+
     // Recipes route (default admin-htmx page)
     root.defineRoute(
       {
@@ -364,17 +445,14 @@ export class HtmxAdminManager {
           }, Buffer.from("Redirecting to login...", "utf-8"));
         }
 
-        // Non-admins do not get the admin Recipes page; land them on their first
-        // accessible wiki instead of a dead-end 403. The front door (GET /) and the
-        // catch-all fallback both funnel here, so this is the single landing chokepoint.
+        // Non-admins do not get the admin Recipes page; send them to their user
+        // home page, which lists the wikis they can reach (and a logout). The
+        // front door (GET /) and the catch-all fallback also route non-admins to
+        // /home, so /home is the single non-admin landing.
         if (!state.user.isAdmin) {
-          const recipeName = await HtmxAdminManager.findFirstAccessibleRecipe(state);
-          if (recipeName) {
-            return state.sendBuffer(302, {
-              "location": `${state.pathPrefix}/wiki/${encodeURIComponent(recipeName)}`,
-            }, Buffer.from("Redirecting to wiki...", "utf-8"));
-          }
-          return HtmxAdminManager.sendNoWiki(state);
+          return state.sendBuffer(302, {
+            "location": `${state.pathPrefix}/home`,
+          }, Buffer.from("Redirecting to home...", "utf-8"));
         }
 
         await serverEvents.emitAsync("admin.htmx.page.accessed", state, state.user.isAdmin);

--- a/packages/mws/src/managers/index.ts
+++ b/packages/mws/src/managers/index.ts
@@ -30,9 +30,17 @@ serverEvents.on("mws.routes", (root: ServerRoute, config: ServerState) => {
     path: /^\/$/,
     method: ["GET"],
   }, async (state) => {
+    // Dispatch the front door by role: anonymous → login; admin → the admin UI;
+    // a normal user → their home page (the wikis they can reach + logout). The
+    // in-wiki "🏠 MWS home" button points here, so this is where it lands.
+    const location = !state.user.isLoggedIn
+      ? `${state.pathPrefix}/login?redirect=${encodeURIComponent(state.pathPrefix + "/")}`
+      : state.user.isAdmin
+        ? `${state.pathPrefix}/admin-htmx`
+        : `${state.pathPrefix}/home`;
     return state.sendBuffer(302, {
-      "location": `${state.pathPrefix}/admin-htmx`,
-    }, Buffer.from("Redirecting to admin...", "utf-8"));
+      "location": location,
+    }, Buffer.from("Redirecting...", "utf-8"));
   });
 });
 

--- a/packages/mws/src/services/__tests__/sessions.test.ts
+++ b/packages/mws/src/services/__tests__/sessions.test.ts
@@ -126,4 +126,36 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
     expect(u.username).toBe("cookieuser");
     expect(u.sessionId).toBe("sess-1");
   });
+
+  it("skips SSO when the mws_no_sso suppress marker is present (logout)", async () => {
+    process.env.MWS_TAILSCALE_SSO = "1";
+    const streamer = {
+      cookies: { getAll: (name: string) => name === "mws_no_sso" ? ["1"] : [] },
+      headers: { "tailscale-user-login": "alice@example.com" },
+    } as any;
+    const u = await SessionManager.parseIncomingRequest(streamer, mkConfig(alice));
+    expect(u.isLoggedIn).toBe(false); // suppressed → anonymous despite a mapped header
+  });
+
+  it("a valid session cookie still wins even with the suppress marker", async () => {
+    process.env.MWS_TAILSCALE_SSO = "1";
+    const streamer = {
+      cookies: { getAll: (name: string) => name === "session" ? ["sess-1"] : name === "mws_no_sso" ? ["1"] : [] },
+      headers: { "tailscale-user-login": "alice@example.com" },
+    } as any;
+    const config = {
+      engine: {
+        sessions: {
+          findFirst: async () => ({
+            session_id: "sess-1",
+            user: { user_id: "u-cookie", username: "cookieuser", nickname: null, disabled: false, roles: [] },
+          }),
+        },
+        users: { findUnique: async () => alice },
+      },
+    } as any;
+    const u = await SessionManager.parseIncomingRequest(streamer, config);
+    expect(u.isLoggedIn).toBe(true);
+    expect(u.username).toBe("cookieuser");
+  });
 });

--- a/packages/mws/src/services/reference-recipes.ts
+++ b/packages/mws/src/services/reference-recipes.ts
@@ -1,0 +1,19 @@
+/**
+ * Standard MWS documentation / reference wikis (recipes). These are opened in a
+ * new browser tab from the user home page (`/home`) and are skipped by the
+ * in-wiki "home" button injection, since they are reference material rather than
+ * a user's working wiki.
+ *
+ * Shared by `managers/admin-htmx.ts` (home-page rendering) and, later,
+ * `managers/WikiStateStore.ts` (home-button injection).
+ */
+export const REFERENCE_RECIPES: ReadonlySet<string> = new Set([
+  "docs",
+  "mws-docs",
+  "dev-docs",
+  "tour",
+]);
+
+export function isReferenceRecipe(recipeName: string): boolean {
+  return REFERENCE_RECIPES.has(recipeName);
+}

--- a/packages/mws/src/services/sessions.ts
+++ b/packages/mws/src/services/sessions.ts
@@ -183,9 +183,17 @@ export class SessionManager {
       isLoggedIn: true,
     };
 
-    // No valid session cookie — try opt-in Tailscale SSO before treating as anonymous.
-    const ssoUser = await SessionManager.resolveTailscaleSSO(streamer, config);
-    if (ssoUser) return ssoUser;
+    // No valid session cookie — try opt-in Tailscale SSO before treating as anonymous,
+    // UNLESS the user just logged out: the short-lived `mws_no_sso` cookie (set by
+    // logout) suppresses SSO so they can stay logged out or sign in as a different
+    // persona by password. It is TTL-bounded, so SSO resumes automatically when it
+    // expires (or immediately via GET /resume-sso). A valid session cookie above
+    // always wins, so password login still works while the marker is present.
+    const ssoSuppressed = streamer.cookies.getAll("mws_no_sso").length > 0;
+    if (!ssoSuppressed) {
+      const ssoUser = await SessionManager.resolveTailscaleSSO(streamer, config);
+      if (ssoUser) return ssoUser;
+    }
 
     return {
       user_id: "" as PrismaField<"Users", "user_id">,
@@ -302,6 +310,15 @@ export class SessionManager {
         secure: state.expectSecure,
         sameSite: "Strict"
       });
+      // Clear any SSO-suppress marker left by a previous logout, so SSO resumes
+      // normally once this password session ends.
+      state.setCookie("mws_no_sso", "", {
+        httpOnly: true,
+        path: state.pathPrefix + "/",
+        expires: new Date(0),
+        secure: state.expectSecure,
+        sameSite: "Strict"
+      });
     }
 
     // NEVER send the session_key! The client already has it!
@@ -341,6 +358,20 @@ export class SessionManager {
         httpOnly: true,
         path: state.pathPrefix + "/",
         expires: new Date(0),
+        secure: state.expectSecure,
+        sameSite: "Strict"
+      });
+    }
+
+    // Under Tailscale SSO, the next request would re-authenticate instantly from the
+    // identity header, making logout a no-op. Set a short-lived suppress marker so
+    // the user actually lands logged out (and can sign in as a different persona);
+    // parseIncomingRequest honours it before SSO. TTL-bounded — SSO resumes after.
+    if (process.env.MWS_TAILSCALE_SSO === "1") {
+      state.setCookie("mws_no_sso", "1", {
+        httpOnly: true,
+        path: state.pathPrefix + "/",
+        expires: new Date(Date.now() + 5 * 60_000),
         secure: state.expectSecure,
         sameSite: "Strict"
       });

--- a/packages/mws/src/templates/htmx-login.html
+++ b/packages/mws/src/templates/htmx-login.html
@@ -37,6 +37,7 @@
                autocomplete="current-password" required>
         <button id="login-submit" class="mws-btn mws-btn-primary" type="submit">Sign in</button>
       </form>
+      {{ssoButton}}
     </div>
   </div>
 


### PR DESCRIPTION
Refs #18.

## What

- **`/home` user home page** (auth-gated, standalone — not the admin frame): **server-renders** the wikis the signed-in user can READ (reusing the Batch 1 ACL query; admin sees all). Reference/doc wikis (`docs`, `mws-docs`, `dev-docs`, `tour`) open in a **new tab**; task wikis in the same tab. Shows a "contact an administrator" message when none, a working **logout**, and a **Manage wikis** link when `isAdmin` (extends to `WIKI_ADMIN` in Batch 3). Replaces Batch 1's redirect-to-first-wiki and the `sendNoWiki` page. (Server-rendered rather than fetching `index_json`, which is behind the `admin()` CSRF gate whose referer allowlist excludes `/home`.)
- **Root dispatch** (`GET /`): anonymous → `/login`, admin → `/admin-htmx`, non-admin → `/home`. The non-admin `/admin-htmx` branch now redirects to `/home`. The in-wiki `🏠 MWS home` button (`href="/"`) therefore lands non-admins on the home page.
- **Logout that works under SSO**: a short-lived (`~5 min`) `mws_no_sso` cookie set on logout, honoured **before** SSO in `parseIncomingRequest`, so the user reaches `/login` and can sign in as another persona by password (session cookie still takes precedence; marker cleared on `login2`). Safe — it can only *force* password login, never weaken auth, and is TTL-bounded.
- **`GET /resume-sso`** + a login-page **"Log in with Tailscale (SSO)"** button (shown only when SSO is enabled) that clears the marker and resumes SSO immediately.
- Shared `REFERENCE_RECIPES` constant (`services/reference-recipes.ts`) — reused by Batch 6's injection skip.

## Why

From live use: a non-admin had no way to switch wikis or sign out (the home button bounced them back to a wiki), and under SSO logout re-authenticated instantly. See #18.

## Tests / checks

- `npm run build` ✅ · `npm run test:unit` ✅ **109 pass** (new `/home` auth-gate/list/empty-state, `/resume-sso`, and SSO-suppress tests incl. session-cookie precedence; Batch 1 redirect tests updated to `/home`).
- `mws-cutover-check` ✅ 0 · `openapi-coverage` ✅ 0 (added `/home`, `/resume-sso` to the spec + the skill's regex lists).

## Notes for review

- No schema change → deploy is a service restart.
- Reference-recipe names confirmed against the live store (`docs`, `mws-docs`, `dev-docs`, `tour`; `moving-house` is the task wiki).

## Follow-on

Batch 6 will inject the `🏠 MWS home` button into served wikis server-side (skipping reference wikis) and drop the hand-coded link from the moving-house-app seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logged-in user home page that lists accessible wikis (with reference wikis opening in a new tab).
  * Implemented role-based redirects from the front door: anonymous → login, admins → admin UI, non-admins → home.
  * Added `/resume-sso` to clear the logout suppress marker and resume SSO flow.
  * Added an optional “Log in with Tailscale (SSO)” button on the login page.
* **Documentation**
  * Documented SSO logout/persona switching behavior and the new home page.
  * Updated OpenAPI routes and redirect behaviors to match.
* **Tests**
  * Updated and added coverage for home and SSO resume routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->