### PR TITLE
Fix: Recipes/Bags admin Save (expose showToast to page fragments)

### DIFF
--- a/packages/mws/src/templates/htmx-admin-frame.html
+++ b/packages/mws/src/templates/htmx-admin-frame.html
@@ -113,6 +113,15 @@
       document.getElementById('toast').classList.remove('mws-show');
     }
 
+    // The frame script is wrapped in an IIFE (above) to avoid top-level const
+    // collisions with injected page fragments. That also hides these helpers from
+    // those fragments, so the Recipes/Bags pages calling showToast() threw
+    // "showToast is not defined" (aborting save → modal never closed). Expose them
+    // on window so every injected page can use the shared toast. (The Users page
+    // defines its own, which is why it was unaffected.)
+    window.showToast = window.showToast || showToast;
+    window.hideToast = window.hideToast || hideToast;
+
     // Initialize on DOM ready
     document.addEventListener('DOMContentLoaded', async () => {
       // Menu toggle


### PR DESCRIPTION
Closes #20.

## What

Expose the frame's `showToast`/`hideToast` on `window` so injected admin page fragments can call them.

## Why

The frame script is wrapped in an IIFE (to avoid a top-level `const pathPrefix` collision with injected fragments). That also trapped `showToast`/`hideToast` in the IIFE scope. The **Recipes** and **Bags** pages call `showToast()` on their save-success path, so it threw `ReferenceError: showToast is not defined` — which aborted before `closeRecipeModal()` + the list reload. The save **actually succeeded server-side** (verified against a copy of the live DB: `recipe_create_or_update` and `recipe_acl_update` both persist), but the dialog never closed, so it looked like nothing saved. The **Users** page was unaffected because it defines its own `showToast`.

## Fix

`window.showToast = window.showToast || showToast;` (and `hideToast`) inside the IIFE — guarded with `|| ` so a page's own definition still wins. Two lines; no behaviour change for the Users page.

## Tests / checks

- `mws-cutover-check` ✅ 0 · `npm run test:unit` ✅ 104.
- Live-repro confirmed via console: `Failed to save recipe: ReferenceError: showToast is not defined`.

Small, independent of the Batch 5 PR (#19) — frame template only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)