### PR TITLE
feat(init-store): seed USER→READ on standard reference wikis

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -59,9 +59,11 @@ these are polish, not correctness):
         enabled user must keep ≥1 role. Docs: `security.md` (controls + access-flow diagram),
         `operations.md` (granting access).
   - [ ] **Batch 2 — least privilege:** remove the `isAdmin` content bypass in
-        `getRecipeACL`/`getBagACL`; seed `USER`-role ACL on the default wikis + connect the initial
-        admin to `USER`; soft role-count cap (~20; no DB cap exists). **Update `SDP.md` access-control
-        section** + the User→Role→ACL diagram here.
+        `getRecipeACL`/`getBagACL`; soft role-count cap (~20; no DB cap exists). **Update `SDP.md`
+        access-control section** + the User→Role→ACL diagram here.
+        - [x] Seed `USER → READ` on the four standard reference wikis (`docs`/`mws-docs`/`dev-docs`/
+          `tour`) at `init-store` so fresh installs get it out of the box (idempotent, additive-only;
+          reuses `REFERENCE_RECIPES`). Live store was already backfilled manually via the ACL editor.
   - [ ] **Batch 3 — `WIKI_ADMIN` tier:** gate recipe/bag create/delete behind
         `isAdmin || WIKI_ADMIN || owner` (today any logged-in user can create); document READ =
         download, WRITE = edit, WIKI_ADMIN = structure/data management.

--- a/packages/mws/src/commands/init-store.ts
+++ b/packages/mws/src/commands/init-store.ts
@@ -3,6 +3,7 @@ import { BaseCommand, CommandInfo } from "@tiddlywiki/commander";
 import { resolve } from "path";
 import { randomInt } from "crypto";
 import { Command as LoadWikiFolderCommand } from "./load-wiki-folder";
+import { REFERENCE_RECIPES } from "../services/reference-recipes";
 
 export const info: CommandInfo = {
 	name: "init-store",
@@ -115,6 +116,40 @@ export class Command extends BaseCommand {
 		await runner(resolve(tweditions, "tour"),
 			"tour", "TiddlyWiki Interactive Tour from https://tiddlywiki.com",
 			"tour", "TiddlyWiki Interactive Tour from https://tiddlywiki.com");
+
+		// Seed `USER -> READ` on the standard reference wikis so any USER-role user
+		// can read them from `/home` on a fresh install (live stores were backfilled
+		// manually via the ACL editor). Runs after the recipes are created above.
+		// Additive and idempotent: it only ADDS the grant when that exact
+		// (recipe, USER, READ) row is absent, never deleting or modifying existing
+		// ACLs, so re-running init-store and any operator-set grants are preserved.
+		// The recipe_acl table has no unique constraint, hence the explicit
+		// existence check rather than relying on createMany skipDuplicates.
+		await this.config.$transaction(async (prisma) => {
+			const userRole = await prisma.roles.findUnique({
+				where: { role_name: "USER" },
+				select: { role_id: true }
+			});
+			if (!userRole) return;
+
+			for (const recipe_name of REFERENCE_RECIPES) {
+				const recipe = await prisma.recipes.findUnique({
+					where: { recipe_name },
+					select: { recipe_id: true }
+				});
+				if (!recipe) continue;
+
+				const existing = await prisma.recipeAcl.findFirst({
+					where: { recipe_id: recipe.recipe_id, role_id: userRole.role_id, permission: "READ" },
+					select: { acl_id: true }
+				});
+				if (existing) continue;
+
+				await prisma.recipeAcl.create({
+					data: { recipe_id: recipe.recipe_id, role_id: userRole.role_id, permission: "READ" }
+				});
+			}
+		});
 
 		this.config.setupRequired = false;
 	}


### PR DESCRIPTION
Closes #22.

## Summary

Fresh installs now grant the `USER` role `READ` on the four standard reference wikis (`docs`, `mws-docs`, `dev-docs`, `tour`) during `init-store`, so any USER-role user sees them on `/home` out of the box. Previously only live stores had this (backfilled manually via the ACL editor).

## Details

- After the existing `runner(...)` recipe-creation block, a new `$transaction` looks up the `USER` role and, for each `REFERENCE_RECIPES` entry, creates a `(recipe, USER, READ)` ACL row **only if absent**.
- **Additive-only** — never deletes/modifies an existing ACL, so live grants and operator-set ACLs are preserved.
- **Idempotent** — explicit existence check (the `recipe_acl` table has no unique constraint).
- Reuses `REFERENCE_RECIPES` from `services/reference-recipes.ts` (same source the `/home` page and home-button work use).
- **No schema/migration change** → deploy = `systemctl restart mws`.

## Testing

- `npm run build` ✓
- `npm run test:unit` → **109/109** ✓
- Full pre-push gate (build, unit, cutover-check, openapi-coverage, npm audit, headless smoke) ✓
- End-to-end on a throwaway store: ran `init-store` **twice**, queried the resulting SQLite — exactly **one** `USER→READ` row per reference recipe (4 total), confirming correctness and idempotency. Live store untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for ACL seeding behavior on standard reference wikis.

* **New Features**
  * Automatic role-based access control seeding during initialization grants read-only permissions to users on standard reference wikis in an idempotent manner, preserving any existing operator-defined permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->