### PR TITLE
feat(acl): admin least privilege for wiki content (access-model Batch 2)

### DIFF
--- a/docs/SDP.md
+++ b/docs/SDP.md
@@ -68,6 +68,17 @@ this server, not a part of it.
     user's `tailscale_login`, stateless, deny-unless-mapped, roles as mapped — safe only because
     MWS is loopback-bound + behind Tailscale Serve (strips spoofed headers) + Funnel off. Password
     login remains the fallback. See `docs/security.md` / `docs/operations.md` §7.
+13. **Access-model series.** Role/ACL/landing rework delivered as staged batches. Highlights:
+    non-admin landing + ACL-editor UI (Batch 1); user home page `/home` + role-based root dispatch
+    (Batch 5); idempotent `USER → READ` seeding of the four reference wikis at `init-store`. **Batch 2
+    — admin least privilege for content:** the `isAdmin` short-circuit in `getRecipeACL`/`getBagACL`
+    is removed, so reading/writing tiddler content requires an explicit ACL grant or ownership for
+    **everyone, including admins** (admins still administer structure via the admin panel, which
+    remains admin-sees-all). The grant chain is unchanged — **User → Role → ACL(role, permission)
+    → Bag/Recipe**, `READ < WRITE < ADMIN` — but `ADMIN` membership no longer implies content
+    access. The initial `admin` user is created with both `ADMIN` and `USER` roles so it reads the
+    default wikis via the seeded grants; `role_create` enforces a soft cap of 20 roles. See
+    `docs/security.md` and `packages/mws/src/RequestState.ts`.
 
 ## 3. Tools & skills
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -58,9 +58,12 @@ these are polish, not correctness):
         (wired to `recipe_acl_update` / `bag_acl_update`); `user_create` auto-assigns `USER` and an
         enabled user must keep ≥1 role. Docs: `security.md` (controls + access-flow diagram),
         `operations.md` (granting access).
-  - [ ] **Batch 2 — least privilege:** remove the `isAdmin` content bypass in
-        `getRecipeACL`/`getBagACL`; soft role-count cap (~20; no DB cap exists). **Update `SDP.md`
-        access-control section** + the User→Role→ACL diagram here.
+  - [x] **Batch 2 — least privilege (DONE):** removed the `isAdmin` content bypass in
+        `getRecipeACL`/`getBagACL` (content needs an explicit ACL grant/ownership for everyone,
+        admins included); initial `admin` user gets `ADMIN`+`USER` roles; soft role-count cap
+        (`ROLE_SOFT_CAP = 20`). `SDP.md` §13 + `security.md` updated. **Deliberately declined**
+        filtering the `index_json` admin management listing — the panel stays admin-sees-all so
+        admins can still administer/grant ACLs on every recipe (content ≠ structural admin).
         - [x] Seed `USER → READ` on the four standard reference wikis (`docs`/`mws-docs`/`dev-docs`/
           `tour`) at `init-store` so fresh installs get it out of the box (idempotent, additive-only;
           reuses `REFERENCE_RECIPES`). Live store was already backfilled manually via the ACL editor.

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,6 +96,18 @@ satisfies all of them.
   See `packages/mws/src/RequestState.ts`. The grant chain is **User → Role → ACL(role,
   permission) → Bag/Recipe**, where `permission` is hierarchical `READ < WRITE < ADMIN`
   (READ = download / read-only, WRITE = edit on the server, ADMIN = manage that resource).
+- **Admin least privilege for content** — `ADMIN`-role users are **not** exempt from content
+  ACLs. `getRecipeACL`/`getBagACL` previously short-circuited the read/write checks to an
+  always-pass query for admins; that bypass is removed, so reading or writing a wiki's tiddler
+  content requires an explicit ACL grant or ownership for everyone, including admins. An admin's
+  authority is to administer *structure* (recipes, bags, ACLs, users) via the admin panel, which
+  is gated separately and still lists every resource. The initial `admin` account created by
+  `init-store` is given the `USER` role in addition to `ADMIN`, so it reads the default reference
+  wikis through the seeded `USER → READ` grants rather than any bypass. See
+  `packages/mws/src/RequestState.ts` and `packages/mws/src/commands/init-store.ts`.
+- **Role-count soft cap** — `role_create` refuses to create more than `ROLE_SOFT_CAP` (20) roles,
+  a guard against accidental role sprawl (no DB constraint; trivially raised in code). See
+  `packages/mws/src/managers/admin-users.ts`.
 - **Access-management UI** — admins set, change, and remove role→permission grants from the
   **Recipes** and **Bags** edit modals ("Access (roles)" section), wired to the existing
   `recipe_acl_update` / `bag_acl_update` admin keys (full-replace semantics). Previously these

--- a/packages/mws/src/RequestState.ts
+++ b/packages/mws/src/RequestState.ts
@@ -76,11 +76,15 @@ export class StateObject<
     recipe_name: PrismaField<"Recipes", "recipe_name">,
     needWrite: boolean
   ) {
-    const { user_id, isAdmin, roles } = this.user;
+    const { user_id, roles } = this.user;
     // AuthUser carries `roles` ({role_id, role_name}); derive the role_ids the
     // ACL helpers expect. Without this, this.user.role_ids is undefined and the
-    // role-based ACL clause in getWhereACL silently drops, so non-admins can only
+    // role-based ACL clause in getWhereACL silently drops, so users can only
     // reach resources they own and every role grant is ignored.
+    // Least privilege: admins are NOT special-cased here. Content (recipe/bag)
+    // access requires an explicit ACL grant or ownership for everyone, including
+    // ADMIN-role users; admins administer structure via the admin panel, which is
+    // gated separately. (Access-model Batch 2.)
     const role_ids = roles.map(r => r.role_id);
 
     const prisma = this.engine;
@@ -93,11 +97,11 @@ export class StateObject<
         select: { recipe_id: true },
         where: { recipe_name }
       }),
-      isAdmin ? prisma.$queryRaw`SELECT 1` : prisma.recipes.findUnique({
+      prisma.recipes.findUnique({
         select: { recipe_id: true },
         where: { recipe_name, recipe_bags: { every: { bag: { OR: read } } } }
       }),
-      isAdmin ? prisma.$queryRaw`SELECT 1` : needWrite ? prisma.recipes.findUnique({
+      needWrite ? prisma.recipes.findUnique({
         select: { recipe_id: true },
         where: { recipe_name, recipe_bags: { some: { position: 0, bag: { OR: write } } } }
       }) : prisma.$queryRaw`SELECT 2`,
@@ -168,11 +172,12 @@ export class StateObject<
     bag_name: PrismaField<"Bags", "bag_name">,
     needWrite: boolean
   ) {
-    const { user_id, isAdmin, roles } = this.user;
+    const { user_id, roles } = this.user;
     // AuthUser carries `roles` ({role_id, role_name}); derive the role_ids the
     // ACL helpers expect. Without this, this.user.role_ids is undefined and the
-    // role-based ACL clause in getWhereACL silently drops, so non-admins can only
+    // role-based ACL clause in getWhereACL silently drops, so users can only
     // reach resources they own and every role grant is ignored.
+    // Least privilege: admins are NOT special-cased here — see getRecipeACL.
     const role_ids = roles.map(r => r.role_id);
     const prisma = this.engine;
     const read = this.getBagWhereACL({ permission: "READ", user_id, role_ids });
@@ -182,11 +187,11 @@ export class StateObject<
         select: { bag_id: true, owner_id: true },
         where: { bag_name }
       }),
-      isAdmin ? prisma.$queryRaw`SELECT 1` : prisma.bags.findUnique({
+      prisma.bags.findUnique({
         select: { bag_id: true },
         where: { bag_name, OR: read }
       }),
-      isAdmin ? prisma.$queryRaw`SELECT 1` : needWrite ? prisma.bags.findUnique({
+      needWrite ? prisma.bags.findUnique({
         select: { bag_id: true },
         where: { bag_name, OR: write }
       }) : prisma.$queryRaw`SELECT 2`,

--- a/packages/mws/src/__tests__/RequestState.acl.test.ts
+++ b/packages/mws/src/__tests__/RequestState.acl.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Access-model Batch 2 — least privilege for content.
+ *
+ * Verifies that getRecipeACL / getBagACL no longer special-case admins: the
+ * read/write permission checks run the real ACL `findUnique` query for everyone,
+ * including ADMIN-role users (previously admins short-circuited to a `SELECT 1`
+ * that always passed). The non-write short-circuit (`SELECT 2` when needWrite is
+ * false) is preserved.
+ *
+ * The methods are exercised against a tagged mock engine so we can assert WHICH
+ * query each `$transaction` slot received, without standing up a real database.
+ */
+import { describe, it, expect } from "vitest";
+import { StateObject } from "../RequestState";
+
+// A query descriptor: the mock engine tags every query it builds so the test can
+// tell an ACL findUnique apart from a bypass `$queryRaw`.
+type Tagged = { kind: string; arg?: any; raw?: any };
+
+function makeEngine() {
+  const findUnique = (model: string) => (arg: any): Tagged => ({ kind: `${model}.findUnique`, arg });
+  return {
+    recipes: { findUnique: findUnique("recipes") },
+    bags: { findUnique: findUnique("bags") },
+    // tagged-template form: prisma.$queryRaw`SELECT 2`
+    $queryRaw: (strings: TemplateStringsArray, ...values: any[]): Tagged =>
+      ({ kind: "queryRaw", raw: strings.join("?") }),
+    // return the slot array verbatim so canRead/canWrite are the descriptors above
+    $transaction: async (arr: Tagged[]) => arr,
+  };
+}
+
+function makeState(isAdmin: boolean) {
+  const state = Object.create(StateObject.prototype) as any;
+  state.engine = makeEngine();
+  state.user = {
+    isLoggedIn: true,
+    isAdmin,
+    user_id: "u1",
+    roles: [{ role_id: "r-admin", role_name: "ADMIN" }],
+  };
+  // headers / pathPrefix are accessor properties on the StreamerState prototype;
+  // shadow them with own data properties for the test instance.
+  Object.defineProperty(state, "headers", { value: {}, configurable: true }); // no referer
+  Object.defineProperty(state, "pathPrefix", { value: "", configurable: true });
+  return state as InstanceType<typeof StateObject>;
+}
+
+describe("RequestState content ACL — admin least privilege (Batch 2)", () => {
+  it("getRecipeACL runs the real ACL read query for an admin (no SELECT-1 bypass)", async () => {
+    const state = makeState(true);
+    const { canRead, canWrite } = await state.getRecipeACL("docs" as any, true) as any;
+    expect(canRead.kind).toBe("recipes.findUnique");
+    expect(canRead.arg.where.recipe_bags).toBeDefined();
+    expect(canWrite.kind).toBe("recipes.findUnique");
+    expect(canWrite.arg.where.recipe_bags.some.position).toBe(0);
+  });
+
+  it("getRecipeACL builds the identical query shape for admin and non-admin", async () => {
+    const admin = await (makeState(true) as any).getRecipeACL("docs" as any, true);
+    const user = await (makeState(false) as any).getRecipeACL("docs" as any, true);
+    expect(admin.canRead).toEqual(user.canRead);
+    expect(admin.canWrite).toEqual(user.canWrite);
+  });
+
+  it("getRecipeACL keeps the SELECT-2 short-circuit when needWrite is false", async () => {
+    const { canWrite } = await (makeState(true) as any).getRecipeACL("docs" as any, false);
+    expect(canWrite.kind).toBe("queryRaw");
+  });
+
+  it("getBagACL runs the real ACL read query for an admin (no SELECT-1 bypass)", async () => {
+    const { canRead, canWrite } = await (makeState(true) as any).getBagACL("docs" as any, true);
+    expect(canRead.kind).toBe("bags.findUnique");
+    expect(canRead.arg.where.OR).toBeDefined();
+    expect(canWrite.kind).toBe("bags.findUnique");
+  });
+
+  it("getBagACL keeps the SELECT-2 short-circuit when needWrite is false", async () => {
+    const { canWrite } = await (makeState(true) as any).getBagACL("docs" as any, false);
+    expect(canWrite.kind).toBe("queryRaw");
+  });
+});

--- a/packages/mws/src/commands/init-store.ts
+++ b/packages/mws/src/commands/init-store.ts
@@ -56,8 +56,15 @@ export class Command extends BaseCommand {
 					]
 				});
 
+				// Connect the initial admin to BOTH ADMIN and USER. The USER role grants
+				// read access to the default reference wikis via the seeded `USER -> READ`
+				// ACLs (see the seeding block below), so the admin can read them without
+				// any admin-specific content bypass (removed in access-model Batch 2).
 				const user = await prisma.users.create({
-					data: { username: "admin", email: "", password: "", roles: { connect: { role_name: "ADMIN" } } },
+					data: {
+						username: "admin", email: "", password: "",
+						roles: { connect: [{ role_name: "ADMIN" }, { role_name: "USER" }] }
+					},
 					select: { user_id: true }
 				});
 

--- a/packages/mws/src/managers/admin-users.ts
+++ b/packages/mws/src/managers/admin-users.ts
@@ -23,6 +23,13 @@ export const UserKeyMap: RouterKeyMap<UserManager, true> = {
 export type UserManagerMap = RouterRouteMap<UserManager>;
 
 /**
+ * Soft cap on the number of roles. There is no DB constraint; this is a guard
+ * against accidental role sprawl (the ACL model is hierarchical and a handful of
+ * roles is expected). Raise this constant if a deployment legitimately needs more.
+ */
+const ROLE_SOFT_CAP = 20;
+
+/**
  * Handle Prisma unique constraint violations and convert to user-friendly error messages
  */
 function handlePrismaUniqueConstraintError(error: unknown): never {
@@ -381,6 +388,10 @@ export class UserManager {
     const { role_name, description } = state.data;
 
     state.okAdmin();
+
+    const roleCount = await prisma.roles.count();
+    if (roleCount >= ROLE_SOFT_CAP)
+      throw `Role limit reached (${ROLE_SOFT_CAP}). Delete an unused role or raise ROLE_SOFT_CAP.`;
 
     return await prisma.roles.create({
       data: { role_name, description }


### PR DESCRIPTION
Closes #24.

## Summary

`ADMIN`-role users no longer bypass content ACLs. `getRecipeACL`/`getBagACL` previously short-circuited the read/write checks to an always-pass `SELECT 1` for admins; that bypass is removed, so reading/writing wiki content now requires an explicit ACL grant or ownership for **everyone, including admins**. Admins still administer structure (recipes, bags, ACLs, users) via the admin panel, which is gated separately and stays admin-sees-all.

## Changes

- **`RequestState.ts`** — drop the `isAdmin ? SELECT 1 :` prefix on the `canRead`/`canWrite` transaction slots in both `getRecipeACL` and `getBagACL`; the non-write `SELECT 2` short-circuit is kept. Admins now run the same role/ownership ACL query as any user.
- **`init-store.ts`** — the initial `admin` user is created with `ADMIN` **and** `USER` roles, so a fresh install reads the four default reference wikis via the seeded `USER → READ` grants (no bypass).
- **`admin-users.ts`** — `role_create` enforces `ROLE_SOFT_CAP = 20` (guard against role sprawl; no DB constraint).
- **Deliberately *not* changed:** `index_json` / admin listings stay admin-sees-all — filtering them would hide recipes from the admin's own management UI and block granting ACLs (content access ≠ structural administration).

## Design decisions (confirmed with the operator)

- Management panel stays admin-sees-all.
- The bare `admin` account loses moving-house *content* access; the operator uses Alistair (ADMIN+household). No ACL change at deploy.

## Testing

- `npm run build` ✓
- `npm run test:unit` → **114/114** (5 new tests in `__tests__/RequestState.acl.test.ts`: admins build the real ACL query, identical query shape to a non-admin, and the `needWrite=false` short-circuit preserved).
- Throwaway store: fresh-install `admin` = `[ADMIN, USER]` with the 4 `USER → READ` seeds.
- Full pre-push gate green (build, unit, cutover-check, openapi-coverage, npm audit, headless smoke).
- Live blast radius verified read-only: only the bare `admin` account loses moving-house content; USER/household/Alistair unaffected.

No schema/migration change → deploy = `systemctl restart mws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security policies and system design documentation with new access control details

* **Bug Fixes**
  * Admin users now enforce content access control requirements like other users; admin panel access unchanged
  * Initial admin account properly assigned required role types for wiki access

* **Chores**
  * Enforced soft limit of 20 roles per system to prevent role sprawl

<!-- end of auto-generated comment: release notes by coderabbit.ai -->