### PR TITLE
feat(acl): WIKI_ADMIN data-management tier (access-model Batch 3)

### DIFF
--- a/docs/SDP.md
+++ b/docs/SDP.md
@@ -79,13 +79,15 @@ this server, not a part of it.
     access. The initial `admin` user is created with both `ADMIN` and `USER` roles so it reads the
     default wikis via the seeded grants; `role_create` enforces a soft cap of 20 roles. See
     `docs/security.md` and `packages/mws/src/RequestState.ts`. **Batch 3 — `WIKI_ADMIN`
-    data-management tier:** creating/deleting recipes and bags now requires `ADMIN` or the new
-    `WIKI_ADMIN` role (previously any logged-in user could create), inserting a structural tier
-    into the model — **READ < WRITE < `WIKI_ADMIN` < `ADMIN`**. A `WIKI_ADMIN` may use the Recipes
-    and Bags admin pages (frame rendered with the real `isAdmin`, so Users/Roles/Settings stay
-    hidden and API-gated) but gets no content-ACL bypass or owner reassignment. The role is seeded
-    by `init-store` for fresh installs. See `packages/mws/src/services/roles.ts` and
-    `packages/mws/src/managers/admin-recipes.ts`.
+    data-management tier:** **creating** a recipe/bag now requires `ADMIN` or the new `WIKI_ADMIN`
+    role (previously any logged-in user; a new resource has no owner); **editing/deleting** an
+    existing one also allows its owner. This inserts a structural tier into the model —
+    **READ < WRITE < `WIKI_ADMIN` < `ADMIN`**. A `WIKI_ADMIN` may use the Recipes and Bags admin
+    pages (frame rendered with the real `isAdmin`, so Users/Roles/Settings stay hidden and
+    API-gated) but gets no content-ACL bypass or owner reassignment. The role name is defined once
+    as the `WIKI_ADMIN_ROLE` constant in `packages/mws/src/services/roles.ts` (imported by both the
+    `init-store` seed and the authorization checks); the role is seeded by `init-store` for fresh
+    installs. See `packages/mws/src/services/roles.ts` and `packages/mws/src/managers/admin-recipes.ts`.
 
 ## 3. Tools & skills
 

--- a/docs/SDP.md
+++ b/docs/SDP.md
@@ -78,7 +78,14 @@ this server, not a part of it.
     → Bag/Recipe**, `READ < WRITE < ADMIN` — but `ADMIN` membership no longer implies content
     access. The initial `admin` user is created with both `ADMIN` and `USER` roles so it reads the
     default wikis via the seeded grants; `role_create` enforces a soft cap of 20 roles. See
-    `docs/security.md` and `packages/mws/src/RequestState.ts`.
+    `docs/security.md` and `packages/mws/src/RequestState.ts`. **Batch 3 — `WIKI_ADMIN`
+    data-management tier:** creating/deleting recipes and bags now requires `ADMIN` or the new
+    `WIKI_ADMIN` role (previously any logged-in user could create), inserting a structural tier
+    into the model — **READ < WRITE < `WIKI_ADMIN` < `ADMIN`**. A `WIKI_ADMIN` may use the Recipes
+    and Bags admin pages (frame rendered with the real `isAdmin`, so Users/Roles/Settings stay
+    hidden and API-gated) but gets no content-ACL bypass or owner reassignment. The role is seeded
+    by `init-store` for fresh installs. See `packages/mws/src/services/roles.ts` and
+    `packages/mws/src/managers/admin-recipes.ts`.
 
 ## 3. Tools & skills
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,9 +67,15 @@ these are polish, not correctness):
         - [x] Seed `USER → READ` on the four standard reference wikis (`docs`/`mws-docs`/`dev-docs`/
           `tour`) at `init-store` so fresh installs get it out of the box (idempotent, additive-only;
           reuses `REFERENCE_RECIPES`). Live store was already backfilled manually via the ACL editor.
-  - [ ] **Batch 3 — `WIKI_ADMIN` tier:** gate recipe/bag create/delete behind
-        `isAdmin || WIKI_ADMIN || owner` (today any logged-in user can create); document READ =
-        download, WRITE = edit, WIKI_ADMIN = structure/data management.
+  - [x] **Batch 3 — `WIKI_ADMIN` tier (DONE):** create/delete of recipes & bags gated behind
+        `isAdmin || WIKI_ADMIN || owner` (was: any logged-in user); `WIKI_ADMIN` role seeded at
+        `init-store`; WIKI_ADMINs admitted to the Recipes/Bags admin pages (frame `isAdmin` stays
+        real → Users/Roles/Settings hidden + API-gated); `/home` manage-link shows for
+        `isAdmin || WIKI_ADMIN`. No content-ACL bypass / owner reassignment for WIKI_ADMIN (those
+        stay `isAdmin`-only). Tier documented READ = download, WRITE = edit, WIKI_ADMIN =
+        structure/data management. New `services/roles.ts` helper; tests in
+        `admin-recipes.acl.test.ts`. No schema change → deploy = restart. Existing deployments
+        create the `WIKI_ADMIN` role via the admin Roles UI.
   - [ ] **Batch 4 — audit + sessions:** `AuditLog` table + read-only admin view (`audit_list`);
         emit points across user/role/recipe/bag/login; cookie idle/absolute timeout; SSO login
         de-dup. **Update `security.md` audit/session section + `SDP.md`.**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,15 +67,18 @@ these are polish, not correctness):
         - [x] Seed `USER → READ` on the four standard reference wikis (`docs`/`mws-docs`/`dev-docs`/
           `tour`) at `init-store` so fresh installs get it out of the box (idempotent, additive-only;
           reuses `REFERENCE_RECIPES`). Live store was already backfilled manually via the ACL editor.
-  - [x] **Batch 3 — `WIKI_ADMIN` tier (DONE):** create/delete of recipes & bags gated behind
-        `isAdmin || WIKI_ADMIN || owner` (was: any logged-in user); `WIKI_ADMIN` role seeded at
+  - [x] **Batch 3 — `WIKI_ADMIN` tier (DONE):** **creating** a recipe/bag now requires
+        `isAdmin || WIKI_ADMIN` (was: any logged-in user — a new resource has no owner);
+        **editing/deleting** an existing one requires `isAdmin || WIKI_ADMIN || owner`. `WIKI_ADMIN` role seeded at
         `init-store`; WIKI_ADMINs admitted to the Recipes/Bags admin pages (frame `isAdmin` stays
         real → Users/Roles/Settings hidden + API-gated); `/home` manage-link shows for
         `isAdmin || WIKI_ADMIN`. No content-ACL bypass / owner reassignment for WIKI_ADMIN (those
         stay `isAdmin`-only). Tier documented READ = download, WRITE = edit, WIKI_ADMIN =
-        structure/data management. New `services/roles.ts` helper; tests in
-        `admin-recipes.acl.test.ts`. No schema change → deploy = restart. Existing deployments
-        create the `WIKI_ADMIN` role via the admin Roles UI.
+        structure/data management. New `services/roles.ts` defines the canonical role name as the
+        `WIKI_ADMIN_ROLE` constant (value `"WIKI_ADMIN"`) plus the `hasWikiAdmin` helper — used by
+        both the `init-store` seed and the authorization checks so the name has a single source of
+        truth. Tests in `admin-recipes.acl.test.ts`. No schema change → deploy = restart. Existing
+        deployments create the `WIKI_ADMIN` role via the admin Roles UI.
   - [ ] **Batch 4 — audit + sessions:** `AuditLog` table + read-only admin view (`audit_list`);
         emit points across user/role/recipe/bag/login; cookie idle/absolute timeout; SSO login
         de-dup. **Update `security.md` audit/session section + `SDP.md`.**

--- a/docs/security.md
+++ b/docs/security.md
@@ -105,6 +105,19 @@ satisfies all of them.
   `init-store` is given the `USER` role in addition to `ADMIN`, so it reads the default reference
   wikis through the seeded `USER → READ` grants rather than any bypass. See
   `packages/mws/src/RequestState.ts` and `packages/mws/src/commands/init-store.ts`.
+- **`WIKI_ADMIN` data-management tier** — a middle authorization tier between content
+  permissions and site administration. The full model is:
+  **READ** (download / local use) < **WRITE** (server-side content edit) < **`WIKI_ADMIN`**
+  (structure: create & delete recipes and bags) < **`ADMIN`** (system administration: users,
+  roles, every ACL, owner reassignment). Creating a recipe or bag previously required only a
+  logged-in session; it now requires `ADMIN` or `WIKI_ADMIN` (or, for editing/deleting an
+  existing resource, ownership). A `WIKI_ADMIN` reaches the Recipes and Bags admin pages to do
+  this, but the admin frame is rendered with the real `isAdmin` flag, so the Users / Roles /
+  Settings sections stay hidden and remain `isAdmin`-gated at the API. Holding `WIKI_ADMIN`
+  grants **no** content-ACL bypass and **no** owner reassignment — those stay `isAdmin`-only
+  (least privilege). The role is seeded on fresh installs by `init-store`; existing deployments
+  add it via the admin Roles UI. See `packages/mws/src/services/roles.ts`,
+  `packages/mws/src/managers/admin-recipes.ts`, and `packages/mws/src/managers/admin-htmx.ts`.
 - **Role-count soft cap** — `role_create` refuses to create more than `ROLE_SOFT_CAP` (20) roles,
   a guard against accidental role sprawl (no DB constraint; trivially raised in code). See
   `packages/mws/src/managers/admin-users.ts`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -116,7 +116,9 @@ satisfies all of them.
   Settings sections stay hidden and remain `isAdmin`-gated at the API. Holding `WIKI_ADMIN`
   grants **no** content-ACL bypass and **no** owner reassignment — those stay `isAdmin`-only
   (least privilege). The role is seeded on fresh installs by `init-store`; existing deployments
-  add it via the admin Roles UI. See `packages/mws/src/services/roles.ts`,
+  add it via the admin Roles UI. The role name is defined once as the `WIKI_ADMIN_ROLE` constant
+  (value `"WIKI_ADMIN"`) in `packages/mws/src/services/roles.ts`, which the seed and the
+  authorization checks both import. See `packages/mws/src/services/roles.ts`,
   `packages/mws/src/managers/admin-recipes.ts`, and `packages/mws/src/managers/admin-htmx.ts`.
 - **Role-count soft cap** — `role_create` refuses to create more than `ROLE_SOFT_CAP` (20) roles,
   a guard against accidental role sprawl (no DB constraint; trivially raised in code). See

--- a/packages/mws/src/commands/init-store.ts
+++ b/packages/mws/src/commands/init-store.ts
@@ -53,6 +53,11 @@ export class Command extends BaseCommand {
 					data: [
 						{ role_name: "ADMIN", description: "System Administrator" },
 						{ role_name: "USER", description: "Basic User" },
+						// Wiki data-management tier (access-model Batch 3): may create and
+						// delete recipes/bags WITHOUT site-admin content access. See
+						// services/roles.ts. Existing deployments add this role via the
+						// admin Users/Roles UI; init-store seeds it for fresh installs.
+						{ role_name: "WIKI_ADMIN", description: "Wiki data management" },
 					]
 				});
 

--- a/packages/mws/src/commands/init-store.ts
+++ b/packages/mws/src/commands/init-store.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import { randomInt } from "crypto";
 import { Command as LoadWikiFolderCommand } from "./load-wiki-folder";
 import { REFERENCE_RECIPES } from "../services/reference-recipes";
+import { WIKI_ADMIN_ROLE } from "../services/roles";
 
 export const info: CommandInfo = {
 	name: "init-store",
@@ -57,7 +58,7 @@ export class Command extends BaseCommand {
 						// delete recipes/bags WITHOUT site-admin content access. See
 						// services/roles.ts. Existing deployments add this role via the
 						// admin Users/Roles UI; init-store seeds it for fresh installs.
-						{ role_name: "WIKI_ADMIN", description: "Wiki data management" },
+						{ role_name: WIKI_ADMIN_ROLE, description: "Wiki data management" },
 					]
 				});
 

--- a/packages/mws/src/managers/__tests__/admin-recipes.acl.test.ts
+++ b/packages/mws/src/managers/__tests__/admin-recipes.acl.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Access-model Batch 3 — WIKI_ADMIN structural authorization.
+ *
+ * Covers `RecipeManager.assertCreateOrUpdate` (the create/update gate shared by
+ * recipe_create_or_update / bag_create_or_update) and the `hasWikiAdmin` helper.
+ * Least-privilege intent: creating a recipe/bag now requires site-admin or the
+ * WIKI_ADMIN role (previously any logged-in user); editing requires admin,
+ * WIKI_ADMIN, or ownership.
+ */
+
+import { describe, it, expect } from "vitest";
+import { RecipeManager } from "../admin-recipes";
+import { hasWikiAdmin } from "../../services/roles";
+
+const mgr = new RecipeManager();
+
+const userWith = (opts: { isAdmin?: boolean; roleNames?: string[]; user_id?: string; isLoggedIn?: boolean }): any => ({
+  isLoggedIn: opts.isLoggedIn ?? true,
+  user_id: opts.user_id ?? "u1",
+  isAdmin: opts.isAdmin ?? false,
+  roles: (opts.roleNames ?? []).map((role_name, i) => ({ role_id: `r${i}`, role_name })),
+});
+
+const PLAIN = userWith({ roleNames: ["USER"] });
+const WIKI = userWith({ roleNames: ["USER", "WIKI_ADMIN"] });
+const ADMIN = userWith({ isAdmin: true, roleNames: ["ADMIN"] });
+
+const call = (existing: any, isCreate: boolean, user: any, owner_id?: any) =>
+  () => mgr.assertCreateOrUpdate({ existing, isCreate, owner_id, type: "recipe", user });
+
+describe("Batch 3 — assertCreateOrUpdate (structural gate)", () => {
+  it("rejects an unauthenticated user", () => {
+    expect(call(null, true, userWith({ isLoggedIn: false }))).toThrow(/not authenticated/);
+  });
+
+  it("rejects a plain USER creating a recipe", () => {
+    expect(call(null, true, PLAIN)).toThrow(/WIKI_ADMIN/);
+  });
+
+  it("allows a WIKI_ADMIN to create a recipe", () => {
+    expect(call(null, true, WIKI)).not.toThrow();
+  });
+
+  it("allows a site-admin to create a recipe", () => {
+    expect(call(null, true, ADMIN)).not.toThrow();
+  });
+
+  it("rejects a create-via-upsert (isCreate=false, no existing) for a plain USER", () => {
+    // The upsert path passes create_only=false; `!existing` still gates it.
+    expect(call(null, false, PLAIN)).toThrow(/WIKI_ADMIN/);
+  });
+
+  it("allows the owner to edit their existing recipe", () => {
+    expect(call({ owner_id: "u1" }, false, PLAIN)).not.toThrow();
+  });
+
+  it("rejects a non-owner plain USER editing an existing recipe", () => {
+    expect(call({ owner_id: "someone-else" }, false, PLAIN)).toThrow(/does not own/);
+  });
+
+  it("allows a WIKI_ADMIN to edit a recipe they do not own", () => {
+    expect(call({ owner_id: "someone-else" }, false, WIKI)).not.toThrow();
+  });
+
+  it("keeps owner_id assignment site-admin-only (WIKI_ADMIN cannot)", () => {
+    expect(call(null, true, WIKI, "someone-else")).toThrow(/owner_id is only valid for admins/);
+    expect(call(null, true, ADMIN, "someone-else")).not.toThrow();
+  });
+});
+
+describe("Batch 3 — hasWikiAdmin", () => {
+  it("is true when the WIKI_ADMIN role is present", () => {
+    expect(hasWikiAdmin(WIKI)).toBe(true);
+  });
+  it("is false for a plain USER", () => {
+    expect(hasWikiAdmin(PLAIN)).toBe(false);
+  });
+  it("is false (not throwing) when roles is missing", () => {
+    expect(hasWikiAdmin({} as any)).toBe(false);
+  });
+});

--- a/packages/mws/src/managers/admin-htmx.ts
+++ b/packages/mws/src/managers/admin-htmx.ts
@@ -4,6 +4,7 @@ import { ServerRoute, dist_resolve, dist_require_resolve, ServerRequest } from "
 import { serverEvents } from "@tiddlywiki/events";
 import { createHash } from "crypto";
 import { REFERENCE_RECIPES } from "../services/reference-recipes";
+import { hasWikiAdmin } from "../services/roles";
 
 declare module "@tiddlywiki/events" {
   interface ServerEventsMap {
@@ -192,8 +193,9 @@ export class HtmxAdminManager {
    */
   private static renderUserHome(state: ServerRequest, recipeNames: string[]) {
     const prefix = state.pathPrefix;
-    // Manage-wikis is admin-only today; Batch 3 extends this to WIKI_ADMIN.
-    const canManage = state.user.isAdmin;
+    // Manage-wikis is for the structural tier: site-admins and WIKI_ADMINs
+    // (the latter can create/delete recipes & bags from the admin panel).
+    const canManage = state.user.isAdmin || hasWikiAdmin(state.user);
 
     const list = recipeNames.map(name => {
       const ref = REFERENCE_RECIPES.has(name);
@@ -445,11 +447,13 @@ export class HtmxAdminManager {
           }, Buffer.from("Redirecting to login...", "utf-8"));
         }
 
-        // Non-admins do not get the admin Recipes page; send them to their user
-        // home page, which lists the wikis they can reach (and a logout). The
-        // front door (GET /) and the catch-all fallback also route non-admins to
-        // /home, so /home is the single non-admin landing.
-        if (!state.user.isAdmin) {
+        // Site-admins and WIKI_ADMINs get the structural Recipes page; everyone
+        // else is sent to their user home page, which lists the wikis they can
+        // reach (and a logout). The frame is rendered with the real `isAdmin`
+        // below, so a WIKI_ADMIN sees Recipes/Bags but NOT the admin-only Users/
+        // Roles/Settings nav. The front door (GET /) and the catch-all fallback
+        // also route plain users to /home, so /home is the single user landing.
+        if (!state.user.isAdmin && !hasWikiAdmin(state.user)) {
           return state.sendBuffer(302, {
             "location": `${state.pathPrefix}/home`,
           }, Buffer.from("Redirecting to home...", "utf-8"));
@@ -493,7 +497,8 @@ export class HtmxAdminManager {
           }, Buffer.from("Redirecting to login...", "utf-8"));
         }
 
-        if (!state.user.isAdmin) {
+        // Bags are structural: site-admins and WIKI_ADMINs may manage them.
+        if (!state.user.isAdmin && !hasWikiAdmin(state.user)) {
           await serverEvents.emitAsync("admin.htmx.page.forbidden", state, state.user.username || "unknown");
           return HtmxAdminManager.send403(state);
         }

--- a/packages/mws/src/managers/admin-recipes.ts
+++ b/packages/mws/src/managers/admin-recipes.ts
@@ -1,6 +1,7 @@
 import { registerZodRoutes, RouterKeyMap, RouterRouteMap, ServerRequest, ServerRoute } from "@tiddlywiki/server";
 import { admin } from "./admin-utils";
 import { serverEvents } from "@tiddlywiki/events";
+import { hasWikiAdmin } from "../services/roles";
 
 
 serverEvents.on("mws.routes", (root) => {
@@ -172,6 +173,10 @@ export class RecipeManager {
       throw "User not authenticated";
 
     const { isAdmin, user_id } = user;
+    // Structure (create/delete/restructure) is the WIKI_ADMIN tier; site-admins
+    // are always permitted. Least privilege: this does NOT grant content access
+    // or owner reassignment, which remain `isAdmin`-only below and elsewhere.
+    const isStructureAdmin = isAdmin || hasWikiAdmin(user);
 
     if (!isAdmin && owner_id !== undefined)
       throw "owner_id is only valid for admins";
@@ -179,7 +184,14 @@ export class RecipeManager {
     if (existing && isCreate)
       throw `A ${type} with this name already exists`;
 
-    if (existing && !isAdmin && existing.owner_id !== user_id)
+    // Creating a NEW recipe/bag is a structural operation. Previously any
+    // logged-in user could create; now it requires the WIKI_ADMIN role (or
+    // site-admin). `!existing` covers both create_only and the upsert path.
+    if (!existing && !isStructureAdmin)
+      throw `Creating a ${type} requires the WIKI_ADMIN role`;
+
+    // Editing an existing recipe/bag: site-admin, WIKI_ADMIN, or the owner.
+    if (existing && !isStructureAdmin && existing.owner_id !== user_id)
       throw `User does not own the ${type} and is not an admin`;
 
   }
@@ -199,7 +211,8 @@ export class RecipeManager {
 
     const { isAdmin, user_id } = state.user;
 
-    if (!isAdmin && recipe.owner_id !== user_id)
+    // Deleting is a structural operation: site-admin, WIKI_ADMIN, or the owner.
+    if (!isAdmin && !hasWikiAdmin(state.user) && recipe.owner_id !== user_id)
       throw "User does not own the recipe and is not an admin";
 
     await prisma.recipes.delete({
@@ -225,7 +238,8 @@ export class RecipeManager {
 
     const { isAdmin, user_id } = state.user;
 
-    if (!isAdmin && bag.owner_id !== user_id)
+    // Deleting is a structural operation: site-admin, WIKI_ADMIN, or the owner.
+    if (!isAdmin && !hasWikiAdmin(state.user) && bag.owner_id !== user_id)
       throw "User does not own the bag and is not an admin";
 
     if (bag._count.tiddlers)

--- a/packages/mws/src/services/roles.ts
+++ b/packages/mws/src/services/roles.ts
@@ -1,0 +1,28 @@
+import type { ServerRequest } from "@tiddlywiki/server";
+
+/**
+ * Canonical role name for the wiki data-management tier.
+ *
+ * `WIKI_ADMIN` grants STRUCTURAL operations — creating and deleting recipes and
+ * bags — without the broader site-admin content access. This is the middle tier
+ * of the access model:
+ *   READ       = download / local use
+ *   WRITE      = server-side content edit
+ *   WIKI_ADMIN = structure / data management (create & delete recipes/bags)
+ *   ADMIN      = system administration (users, roles, every ACL)
+ *
+ * Least privilege: holding WIKI_ADMIN is NOT the same as being a site-admin. It
+ * never confers the content-ACL bypass or owner reassignment reserved for
+ * `isAdmin`.
+ */
+export const WIKI_ADMIN_ROLE = "WIKI_ADMIN";
+
+/**
+ * Whether the user holds the `WIKI_ADMIN` data-management role. Mirrors the
+ * `isAdmin` derivation (membership of the `ADMIN` role) used by the auth service.
+ * Defensive against a missing/empty roles array (e.g. anonymous requests).
+ */
+export function hasWikiAdmin(user: ServerRequest["user"]): boolean {
+  return Array.isArray(user?.roles)
+    && user.roles.some(r => r.role_name === WIKI_ADMIN_ROLE);
+}


### PR DESCRIPTION
## Access-model Batch 3 — `WIKI_ADMIN` data-management tier

Closes #26.

Inserts a structural authorization tier between content permissions and site administration:

**`READ`** (download/local use) < **`WRITE`** (server-side content edit) < **`WIKI_ADMIN`** (structure: create/delete recipes & bags) < **`ADMIN`** (system administration).

### Changes
- **`admin-recipes.ts`** — creating a recipe/bag now requires `ADMIN` or `WIKI_ADMIN` (was: any logged-in user); editing/deleting an existing one requires `ADMIN`, `WIKI_ADMIN`, or ownership. Owner reassignment and the content-ACL bypass stay `isAdmin`-only (least privilege).
- **`init-store.ts`** — seeds the `WIKI_ADMIN` role ("Wiki data management") on fresh installs. Existing deployments add it via the admin Roles UI.
- **`admin-htmx.ts`** — `WIKI_ADMIN`s are admitted to the Recipes and Bags admin pages; the admin frame is rendered with the **real** `isAdmin`, so the Users/Roles/Settings nav stays hidden and those routes remain `isAdmin`-gated. The `/home` "Manage wikis" link shows for `isAdmin || WIKI_ADMIN`.
- **`services/roles.ts`** (new) — `WIKI_ADMIN_ROLE` constant + `hasWikiAdmin(user)` helper (mirrors the `isAdmin` derivation; defensive against missing roles).
- **Docs** — `security.md`, `SDP.md §13`, `TODO.md`.

### Verification
- `npm run build` ✓ · `npm run test:unit` → **126/126** (+12 new in `admin-recipes.acl.test.ts`) ✓
- `mws-cutover-check` 0 failures · `openapi-coverage` 0 failures · `npm audit --omit=dev` 0 vulns · headless smoke PASSED

No schema change → deploy = `systemctl restart mws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Wiki Admin** authorization tier for managing wiki structures (recipes and bags), allowing create/edit/delete within defined boundaries.
  * Updated admin UI access so Wiki Admins can reach the relevant structural admin pages.
  * Fresh installs now seed the Wiki Admin role automatically.

* **Documentation**
  * Expanded the access-model and security docs with the Wiki Admin tier rules and boundaries.

* **Tests**
  * Added ACL tests covering Wiki Admin create/edit/delete behavior and role checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->