### PR TITLE
feat(sessions): session lifecycle — idle/absolute timeout, last_login, SSO login de-dup (Batch 4b)

### DIFF
--- a/docs/SDP.md
+++ b/docs/SDP.md
@@ -95,7 +95,13 @@ this server, not a part of it.
     so audit never breaks a request; no secrets/OPAQUE/session-ids/headers are stored. A read-only,
     filterable, paged admin view is served at `/admin-htmx/audit` (`audit_list` key). The session
     lifecycle (idle/absolute timeout) + SSO login de-dup follow in Batch 4b. See
-    `packages/mws/src/services/audit.ts`.
+    `packages/mws/src/services/audit.ts`. **Batch 4b — session lifecycle:** cookie sessions
+    expire on idle (30 min) and an absolute cap (12 h), enforced in `parseIncomingRequest` (the
+    expired row is deleted and the request falls through to re-authentication); `last_accessed` is
+    refreshed on use but throttled (≤ once/min); the cookie `expires` is set to the absolute cap;
+    `last_login` is written on password login; and the stateless Tailscale SSO `sso.login` audit
+    event is de-duplicated via a bounded per-user LRU (one row per > 30 min activity gap, not per
+    request). See `packages/mws/src/services/sessions.ts`.
 
 ## 3. Tools & skills
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -87,9 +87,13 @@ these are polish, not correctness):
           rolled-back action; read-only filterable paged view `/admin-htmx/audit` (`audit_list`
           key) + OpenAPI. No secrets/OPAQUE/session-ids/headers stored. Docs: `security.md`,
           `operations.md §8`, `SDP.md`.
-    - [ ] **4b — session lifecycle:** cookie `Max-Age`; throttled `last_accessed` refresh; idle
-          30 min / absolute 12 h expiry; write `last_login`; SSO login de-dup (bounded LRU, 30-min
-          window) + `sso.login` audit emit. Changes live login behaviour → own review/deploy.
+    - [x] **4b — session lifecycle (DONE):** cookie `expires` set to the absolute cap; throttled
+          `last_accessed` refresh (≤ once/min); **idle 30 min / absolute 12 h** expiry enforced in
+          `parseIncomingRequest` (expired row deleted → re-auth); `last_login` written on password
+          login; SSO `sso.login` de-dup via bounded per-user LRU (one row per > 30 min activity
+          gap). Pure helpers `isSessionExpired` / `touchSsoActivity` unit-tested. **Changes live
+          login behaviour** (users re-auth after idle/absolute timeout) → deploy = restart. Docs:
+          `security.md`, `SDP.md`.
     - [ ] **4c — audit-log archival / forwarding (future):** a separate, internal process running
           *on the same machine as the MWS service*, with permission to archive the `audit_log`,
           that periodically (e.g. daily/weekly) extracts that window's entries, produces a summary

--- a/docs/security.md
+++ b/docs/security.md
@@ -138,8 +138,16 @@ satisfies all of them.
   outcome (success/denied/error), optional target, and a small non-sensitive `detail` bag —
   **never** passwords, OPAQUE material, session ids/keys, or raw headers. Admins read the trail
   (newest first, filterable, paged) at the read-only **Audit log** page (`/admin-htmx/audit`,
-  `audit_list` key); viewing it is not itself audited. (Session-lifecycle auditing — SSO login
-  de-dup — lands with the session-timeout work in Batch 4b.)
+  `audit_list` key); viewing it is not itself audited.
+- **Session lifecycle** — cookie sessions expire on **idle (30 min)** and an **absolute cap
+  (12 h)**, whichever comes first, enforced server-side in `parseIncomingRequest`: an expired
+  session row is deleted and the request falls through to anonymous (re-authentication required).
+  `last_accessed` is refreshed on use but **throttled** (≤ once/min) to avoid write amplification;
+  the session cookie's `expires` is set to the absolute cap; `last_login` is written on a
+  successful password login. Tailscale SSO is stateless (re-validated per request), so an
+  `sso.login` audit event is **de-duplicated** via a bounded per-user LRU — only the first request
+  after a > 30 min activity gap is logged as a new session, so a page-refresh storm does not flood
+  the trail. See `packages/mws/src/services/sessions.ts`.
 - **Access-management UI** — admins set, change, and remove role→permission grants from the
   **Recipes** and **Bags** edit modals ("Access (roles)" section), wired to the existing
   `recipe_acl_update` / `bag_acl_update` admin keys (full-replace semantics). Previously these

--- a/packages/mws/src/services/__tests__/sessions.test.ts
+++ b/packages/mws/src/services/__tests__/sessions.test.ts
@@ -115,8 +115,12 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
         sessions: {
           findFirst: async () => ({
             session_id: "sess-1",
+            created_at: new Date(),
+            last_accessed: new Date(),
             user: { user_id: "u-cookie", username: "cookieuser", nickname: null, disabled: false, roles: [] },
           }),
+          update: async () => ({}),
+          delete: async () => ({}),
         },
         users: { findUnique: async () => alice }, // would match, but the cookie must win
       },
@@ -148,8 +152,12 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
         sessions: {
           findFirst: async () => ({
             session_id: "sess-1",
+            created_at: new Date(),
+            last_accessed: new Date(),
             user: { user_id: "u-cookie", username: "cookieuser", nickname: null, disabled: false, roles: [] },
           }),
+          update: async () => ({}),
+          delete: async () => ({}),
         },
         users: { findUnique: async () => alice },
       },
@@ -157,5 +165,58 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
     const u = await SessionManager.parseIncomingRequest(streamer, config);
     expect(u.isLoggedIn).toBe(true);
     expect(u.username).toBe("cookieuser");
+  });
+
+  it("expires an idle session and deletes it (falls through to anonymous)", async () => {
+    delete process.env.MWS_TAILSCALE_SSO; // no SSO fallback — expect anonymous
+    const now = Date.now();
+    let deleted = false;
+    const streamer = { cookies: { getAll: (n: string) => n === "session" ? ["sess-old"] : [] }, headers: {} } as any;
+    const config = {
+      engine: {
+        sessions: {
+          findFirst: async () => ({
+            session_id: "sess-old",
+            created_at: new Date(now - 60_000),                                  // fresh-ish
+            last_accessed: new Date(now - SessionManager.SESSION_IDLE_MS - 1000), // idle past 30 min
+            user: { user_id: "u1", username: "alice", nickname: null, disabled: false, roles: [] },
+          }),
+          update: async () => ({}),
+          delete: async ({ where }: any) => { if (where.session_id === "sess-old") deleted = true; return {}; },
+        },
+      },
+    } as any;
+    const u = await SessionManager.parseIncomingRequest(streamer, config);
+    expect(u.isLoggedIn).toBe(false);
+    expect(deleted).toBe(true);
+  });
+});
+
+describe("SessionManager.isSessionExpired", () => {
+  const now = 1_000_000_000_000;
+  it("is false for a fresh session", () => {
+    expect(SessionManager.isSessionExpired(new Date(now), new Date(now), now)).toBe(false);
+  });
+  it("is true past the idle window", () => {
+    const created = new Date(now - 60_000);
+    const accessed = new Date(now - SessionManager.SESSION_IDLE_MS - 1);
+    expect(SessionManager.isSessionExpired(created, accessed, now)).toBe(true);
+  });
+  it("is true past the absolute cap even if recently accessed", () => {
+    const created = new Date(now - SessionManager.SESSION_ABSOLUTE_MS - 1);
+    expect(SessionManager.isSessionExpired(created, new Date(now), now)).toBe(true);
+  });
+});
+
+describe("SessionManager.touchSsoActivity", () => {
+  it("treats the first request and a post-gap request as new, but not within the sliding window", () => {
+    const uid = "sso-user-" + Math.random();
+    const t0 = 5_000_000;
+    const W = SessionManager.SSO_LOGIN_WINDOW_MS;
+    expect(SessionManager.touchSsoActivity(uid, t0)).toBe(true);            // first → new
+    expect(SessionManager.touchSsoActivity(uid, t0 + 1000)).toBe(false);    // within window → continuation
+    // Sliding window: each touch resets the clock, so "new" needs a gap > window
+    // since the LAST activity (t0 + 1000), not since the first.
+    expect(SessionManager.touchSsoActivity(uid, t0 + 1000 + W + 1)).toBe(true);
   });
 });

--- a/packages/mws/src/services/sessions.ts
+++ b/packages/mws/src/services/sessions.ts
@@ -162,27 +162,80 @@ export class SessionManager {
     }
   }
 
+  // ── Session lifecycle (Batch 4b) ─────────────────────────────────────────
+  // Cookie sessions expire on BOTH an idle window (no use for 30 min) and an
+  // absolute cap (12 h since creation), whichever comes first. `last_accessed` is
+  // refreshed on use, but throttled so a burst of requests is not a write storm.
+  static readonly SESSION_IDLE_MS = 30 * 60_000;          // 30 minutes idle
+  static readonly SESSION_ABSOLUTE_MS = 12 * 60 * 60_000; // 12 hours absolute
+  static readonly SESSION_ACCESS_REFRESH_MS = 60_000;     // refresh last_accessed at most once/min
+
+  /** Pure expiry decision (idle OR absolute). */
+  static isSessionExpired(created_at: Date, last_accessed: Date, now: number = Date.now()): boolean {
+    return (now - created_at.getTime() > SessionManager.SESSION_ABSOLUTE_MS)
+      || (now - last_accessed.getTime() > SessionManager.SESSION_IDLE_MS);
+  }
+
+  // ── SSO login de-duplication (Batch 4b) ──────────────────────────────────
+  // SSO is stateless (re-validated per request), so without de-dup every page
+  // refresh would log a `sso.login`. Track the last-seen time per user in a
+  // bounded LRU and only treat a request as a NEW login (worth auditing) when no
+  // activity has been seen within the window. Mirrors the rate-limit LRU.
+  private static ssoActivity = new Map<string, number>();
+  static readonly SSO_LOGIN_WINDOW_MS = 30 * 60_000;
+  static readonly SSO_MAX_TRACKED = 5000;
+
+  /** Records SSO activity for a user; returns true if this starts a NEW session window. */
+  static touchSsoActivity(user_id: string, now: number = Date.now()): boolean {
+    const last = SessionManager.ssoActivity.get(user_id);
+    const isNew = last === undefined || (now - last) > SessionManager.SSO_LOGIN_WINDOW_MS;
+    // LRU touch: re-insert moves the key to the newest position.
+    SessionManager.ssoActivity.delete(user_id);
+    SessionManager.ssoActivity.set(user_id, now);
+    if (SessionManager.ssoActivity.size > SessionManager.SSO_MAX_TRACKED) {
+      const oldest = SessionManager.ssoActivity.keys().next().value;
+      if (oldest !== undefined) SessionManager.ssoActivity.delete(oldest);
+    }
+    return isNew;
+  }
+
   static async parseIncomingRequest(streamer: Streamer, config: ServerState): Promise<AuthUser> {
 
     const sessionId = streamer.cookies.getAll("session") as PrismaField<"Sessions", "session_id">[];
     const session = sessionId && await config.engine.sessions.findFirst({
       where: { session_id: { in: sessionId } },
-      select: { session_id: true, user: { select: { user_id: true, username: true, nickname: true, disabled: true, roles: { select: { role_id: true, role_name: true } } } } }
+      select: { session_id: true, created_at: true, last_accessed: true, user: { select: { user_id: true, username: true, nickname: true, disabled: true, roles: { select: { role_id: true, role_name: true } } } } }
     });
 
     // A disabled user is treated as logged out (their session no longer authenticates).
-    if (sessionId && session && !session.user.disabled) return {
-      user_id: session.user.user_id,
-      username: session.user.username,
-      nickname: session.user.nickname,
-      isAdmin: session.user.roles.some(e => e.role_name === "ADMIN"),
-      roles: session.user.roles.map(e => ({
-        role_id: e.role_id,
-        role_name: e.role_name
-      })),
-      sessionId: session.session_id,
-      isLoggedIn: true,
-    };
+    if (sessionId && session && !session.user.disabled) {
+      const now = Date.now();
+      if (SessionManager.isSessionExpired(session.created_at, session.last_accessed, now)) {
+        // Idle (30 min) or absolute (12 h) timeout: drop the row and fall through
+        // to SSO/anonymous so the user must re-authenticate.
+        await config.engine.sessions.delete({ where: { session_id: session.session_id } }).catch(() => { });
+      } else {
+        // Sliding idle window: refresh last_accessed, throttled to avoid a write per request.
+        if (now - session.last_accessed.getTime() > SessionManager.SESSION_ACCESS_REFRESH_MS) {
+          await config.engine.sessions.update({
+            where: { session_id: session.session_id },
+            data: { last_accessed: new Date(now) },
+          }).catch(() => { });
+        }
+        return {
+          user_id: session.user.user_id,
+          username: session.user.username,
+          nickname: session.user.nickname,
+          isAdmin: session.user.roles.some(e => e.role_name === "ADMIN"),
+          roles: session.user.roles.map(e => ({
+            role_id: e.role_id,
+            role_name: e.role_name
+          })),
+          sessionId: session.session_id,
+          isLoggedIn: true,
+        };
+      }
+    }
 
     // No valid session cookie — try opt-in Tailscale SSO before treating as anonymous,
     // UNLESS the user just logged out: the short-lived `mws_no_sso` cookie (set by
@@ -230,6 +283,16 @@ export class SessionManager {
       select: { user_id: true, username: true, nickname: true, disabled: true, roles: { select: { role_id: true, role_name: true } } }
     });
     if (!u || u.disabled) return null;
+
+    // Audit a NEW SSO session only (de-duped over a 30-min window) so a page-refresh
+    // storm doesn't write a row per request. Best-effort via the root engine.
+    if (SessionManager.touchSsoActivity(u.user_id)) {
+      await recordAudit(config.engine, {
+        action: "sso.login", outcome: "success",
+        actor_user_id: u.user_id, actor_label: u.username,
+        detail: { method: "tailscale" },
+      });
+    }
 
     return {
       user_id: u.user_id,
@@ -331,18 +394,27 @@ export class SessionManager {
 
     const session_id = await createSession(prisma, value.user_id, value.session.sessionKey);
 
+    // Record the successful login time (Batch 4b: session lifecycle).
+    await prisma.users.update({
+      where: { user_id: value.user_id },
+      data: { last_login: new Date() },
+    });
+
     await recordAudit(state.engine, {
       action: "login.success", outcome: "success",
       actor_user_id: value.user_id, actor_label: account.username,
     });
 
     if (!skipCookie) {
-      // the client can ask to skip the cookie for things like password change
+      // the client can ask to skip the cookie for things like password change.
+      // `expires` caps the cookie at the absolute session lifetime (12 h); the
+      // server still enforces idle + absolute expiry independently (parseIncomingRequest).
       state.setCookie("session", session_id, {
         httpOnly: true,
         path: state.pathPrefix + "/",
         secure: state.expectSecure,
-        sameSite: "Strict"
+        sameSite: "Strict",
+        expires: new Date(Date.now() + SessionManager.SESSION_ABSOLUTE_MS),
       });
       // Clear any SSO-suppress marker left by a previous logout, so SSO resumes
       // normally once this password session ends.


### PR DESCRIPTION
## Access-model Batch 4b — session lifecycle

Closes #30. Completes Batch 4 (4a = audit logging, already merged).

⚠️ **Changes live login behaviour:** existing users will be re-authenticated after the idle/absolute timeout once deployed.

### Changes (`services/sessions.ts`)
- **Idle + absolute expiry** — cookie sessions expire on idle (30 min) **and** an absolute cap (12 h), whichever first, enforced in `parseIncomingRequest`: an expired session row is deleted and the request falls through to anonymous (re-auth required). Pure decision in `isSessionExpired`.
- **Throttled `last_accessed`** — refreshed on use but at most once/min, so a request burst is not a write storm.
- **Cookie `expires`** — set to the absolute cap (server still enforces both windows independently).
- **`last_login`** — written on a successful password login (`/login/2`).
- **SSO login de-dup** — SSO is stateless (re-validated per request), so `sso.login` is audited only on the first request after a > 30 min activity gap, via a bounded per-user LRU (`touchSsoActivity`, mirrors the rate-limit map). No row per page refresh.

### Verification
- `npm run build` ✓ · `npm run test:unit` → **137/137** (+5: `isSessionExpired`, `touchSsoActivity`, idle-expiry path) ✓
- `mws-cutover-check` 0 failures · `openapi-coverage` 0 failures · `npm audit --omit=dev` 0 vulns · headless smoke PASSED

No schema change (uses existing `Sessions.created_at/last_accessed`, `Users.last_login`) → deploy = `systemctl restart mws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now enforce idle timeout and absolute lifetime limits, deleting expired sessions and requiring re-authentication.
  * SSO login audit entries are de-duplicated within a sliding window to prevent duplicate logging.
  * Cookie absolute expiry is now properly set for session management.

* **Documentation**
  * Enhanced security documentation with detailed session lifecycle behavior and cookie handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->