### PR TITLE
test(audit): assert audit data flow + update security data-flow diagram

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -209,10 +209,38 @@ sequenceDiagram
   end
 ```
 
-> **Least-privilege caveat (current state):** an `isAdmin` user still **bypasses** the content
-> ACL in `getRecipeACL`/`getBagACL`, so admins can read/write every wiki today. Removing that
-> blanket bypass (so admins reach content only via role/ownership) is planned for the next batch —
-> see [`SDP.md`](SDP.md) and [`TODO.md`](TODO.md).
+> **Least privilege (current state):** the blanket `isAdmin` content bypass in
+> `getRecipeACL`/`getBagACL` has been **removed** (Batch 2) — admins reach wiki *content* only via
+> a role ACL grant or ownership, like anyone else. Admins retain *structural* administration
+> (the admin panel stays admin-sees-all); `WIKI_ADMIN` is the create/delete tier (Batch 3).
+
+### Audit & session data flow
+
+How a request is authenticated (session lifecycle + SSO) and how administrative, structural,
+and authentication events reach the append-only audit trail, as implemented in
+`services/sessions.ts` and `services/audit.ts`:
+
+```mermaid
+flowchart TD
+  Req["Incoming request"] --> PIR["parseIncomingRequest"]
+
+  PIR --> Cookie{"valid session cookie?"}
+  Cookie -- yes --> Exp{"idle &gt;30m or absolute &gt;12h?"}
+  Exp -- "expired" --> Del["delete session row"] --> Anon["anonymous"]
+  Exp -- "live" --> Refresh["refresh last_accessed (throttled &le;1/min)"] --> Authed["authenticated"]
+  Cookie -- no --> SSO{"Tailscale SSO mapped &amp; enabled?"}
+  SSO -- yes --> Dedup{"new session? (&gt;30m gap, per-user LRU)"}
+  Dedup -- "yes" --> AuditSSO["recordAudit(sso.login)"] --> Authed
+  Dedup -- "no (continuation)" --> Authed
+  SSO -- no --> Anon
+
+  Authed --> Handler["route handler (content ACL / role checks)"]
+  Anon --> Handler
+  Handler --> Events["admin / structural / auth events<br/>(login, logout, user/role, recipe/bag, ACL)"]
+  Events --> Sink["recordAudit() — writes via the ROOT engine,<br/>not the request transaction; secrets redacted; errors swallowed"]
+  Sink --> WORM[("audit_log<br/>append-only WORM: BEFORE UPDATE/DELETE triggers abort")]
+  WORM --> View["GET /admin-htmx/audit (read-only, paged, filterable)"]
+```
 
 - **Error contract** — `Streamer.catcher` honours `SendError.status`/`reason` instead of
   blanket-500ing, so an unauthorized request surfaces as `403`, not `500`.

--- a/packages/mws/src/managers/__tests__/admin-recipes.acl.test.ts
+++ b/packages/mws/src/managers/__tests__/admin-recipes.acl.test.ts
@@ -8,7 +8,7 @@
  * WIKI_ADMIN, or ownership.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { RecipeManager } from "../admin-recipes";
 import { hasWikiAdmin } from "../../services/roles";
 
@@ -77,5 +77,39 @@ describe("Batch 3 — hasWikiAdmin", () => {
   });
   it("is false (not throwing) when roles is missing", () => {
     expect(hasWikiAdmin({} as any)).toBe(false);
+  });
+});
+
+// Representative manager -> audit-sink data-flow test (Batch 4a). All 14 admin/structural
+// emit points use the identical `recordAudit(state.engine, {...})` wiring; this exercises one
+// end to end (recipe_delete) through the real admin() route, confirming the row is written via
+// the ROOT engine (state.engine), not the request transaction client.
+describe("Batch 4a — manager audit emit (recipe_delete)", () => {
+  it("writes a recipe.delete audit row via state.engine", async () => {
+    const auditCreate = vi.fn(async () => ({}));
+    const txnPrisma = {
+      recipes: {
+        findUnique: async () => ({ recipe_id: "rec1", recipe_name: "docs", owner_id: null }),
+        delete: async () => ({}),
+      },
+    };
+    const state: any = {
+      headers: { referer: "http://h/admin", host: "h", origin: "http://h" }, // CSRF passes
+      pathPrefix: "",
+      data: { recipe_name: "docs" },
+      user: { isLoggedIn: true, user_id: "admin1", isAdmin: true, roles: [{ role_id: "r", role_name: "ADMIN" }] },
+      engine: { auditLog: { create: auditCreate } },           // ROOT engine (audit sink)
+      $transaction: async (cb: any) => cb(txnPrisma),           // request txn client (NOT the engine)
+      sendEmpty: (s: number, h: any) => { throw { s, h }; },
+    };
+
+    await mgr.recipe_delete.inner(state);
+
+    expect(auditCreate).toHaveBeenCalledTimes(1);
+    const data = auditCreate.mock.calls[0][0].data;
+    expect(data.action).toBe("recipe.delete");
+    expect(data.outcome).toBe("success");
+    expect(data.target_type).toBe("recipe");
+    expect(data.target_name).toBe("docs");
   });
 });

--- a/packages/mws/src/services/__tests__/sessions.test.ts
+++ b/packages/mws/src/services/__tests__/sessions.test.ts
@@ -3,7 +3,7 @@
  * Time is injected via the `now` argument so the tests are deterministic (no fake timers).
  * Each test uses a unique username to avoid sharing the static in-memory map.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { SessionManager } from "../sessions";
 
 const MAX = SessionManager.LOGIN_MAX_ATTEMPTS;
@@ -67,10 +67,12 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
   const mkStreamer = (header: string | null) =>
     ({ cookies: { getAll: () => [] }, headers: header ? { "tailscale-user-login": header } : {} }) as any;
   // engine: no session; users.findUnique matches only the given user's tailscale_login.
+  // auditLog is a no-op here — the SSO emit (Batch 4b) is asserted explicitly below.
   const mkConfig = (user: any) => ({
     engine: {
       sessions: { findFirst: async () => null },
       users: { findUnique: async ({ where }: any) => (user && where.tailscale_login === user.tailscale_login) ? user : null },
+      auditLog: { create: async () => ({}) },
     },
   }) as any;
   const resolve = (header: string | null, user: any) =>
@@ -92,6 +94,32 @@ describe("SessionManager.parseIncomingRequest — Tailscale SSO", () => {
   it("denies an unmapped identity (no auto-provision)", async () => {
     process.env.MWS_TAILSCALE_SSO = "1";
     expect((await resolve("bob@example.com", alice)).isLoggedIn).toBe(false);
+  });
+
+  it("audits a NEW SSO login (sso.login) and de-dups within the window", async () => {
+    process.env.MWS_TAILSCALE_SSO = "1";
+    // Unique user so the static SSO-activity LRU is deterministic for this test.
+    const u = { tailscale_login: "audit@x", user_id: "u-sso-audit-" + Math.random(), username: "ssoaudit",
+      nickname: null, disabled: false, roles: [] };
+    const create = vi.fn(async () => ({}));
+    const config = {
+      engine: {
+        sessions: { findFirst: async () => null },
+        users: { findUnique: async ({ where }: any) => where.tailscale_login === u.tailscale_login ? u : null },
+        auditLog: { create },
+      },
+    } as any;
+    const streamer = { cookies: { getAll: () => [] }, headers: { "tailscale-user-login": "audit@x" } } as any;
+
+    const first = await SessionManager.parseIncomingRequest(streamer, config);
+    expect(first.isLoggedIn).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);                       // new session → audited
+    expect(create.mock.calls[0][0].data.action).toBe("sso.login");
+    expect(create.mock.calls[0][0].data.outcome).toBe("success");
+
+    const second = await SessionManager.parseIncomingRequest(streamer, config);
+    expect(second.isLoggedIn).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);                       // within window → NOT re-audited
   });
 
   it("denies a disabled mapped user", async () => {


### PR DESCRIPTION
Follow-up to the access-model audit work (Batch 4): make the audit **data flow** explicit in tests and docs.

### Tests
- **`sessions.test.ts`** — `mkConfig` gains a no-op `auditLog` (removes the misleading `undefined.create` stderr); a new test asserts a NEW Tailscale SSO login writes exactly one `sso.login` row and is **de-duped** within the window.
- **`admin-recipes.acl.test.ts`** — a representative manager→sink test drives `recipe_delete` through the real `admin()` route and asserts the `recipe.delete` row is written via the **ROOT engine** (`state.engine`), not the request transaction. All 14 admin/structural emit points share this exact wiring.

### Coverage review (honest gaps)
- Sink (`recordAudit`) — unit-tested (incl. secret redaction, swallow-on-failure). ✓
- SSO emit — now tested. ✓ · Manager emit — representative test. ✓
- **Not yet tested:** `login1`/`login2` emit points (`login.success/failure/lockout`) — they run through the OPAQUE `PasswordService`, for which there's no test harness yet. Flagged for a future test batch.

### Docs (`security.md`)
- **Fix stale caveat** that still claimed `isAdmin` bypasses content ACL — removed in Batch 2.
- **New "Audit & session data flow" Mermaid diagram**: session idle/absolute expiry, SSO de-dup, `recordAudit` via root engine, append-only WORM `audit_log`, read-only view. Both diagrams validated with `mermaid-test`.

### Verification
`npm run build` ✓ · `npm run test:unit` → **139/139** (+2) ✓ · full pre-push gate green (cutover, openapi, audit, smoke). Docs/tests only — no schema/route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security guidance to clarify the removal of a blanket admin bypass for content access and document the audit trail system and session lifecycle.

* **Tests**
  * Enhanced test coverage for audit logging to verify proper recording of admin actions and SSO authentication events, including de-duplication of repeated logins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->